### PR TITLE
Set  autoload to false

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,9 +9,9 @@ class Factory
         // @codeCoverageIgnoreStart
         if (function_exists('event_base_new')) {
             return new LibEventLoop();
-        } else if (class_exists('libev\EventLoop')) {
+        } else if (class_exists('libev\EventLoop', false)) {
             return new LibEvLoop;
-        } else if (class_exists('EventBase')) {
+        } else if (class_exists('EventBase', false)) {
             return new ExtEventLoop;
         }
 


### PR DESCRIPTION
Autoload in `class_exists` function was set to false to prevent autoloading of undefined classes.
