### PR TITLE
Docblock fixes

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -236,8 +236,8 @@ class ExtEventLoop implements LoopInterface
     /**
      * Create a new ext-event Event object, or update the existing one.
      *
-     * @param stream  $stream
-     * @param integer $flag   Event::READ or Event::WRITE
+     * @param resource $stream
+     * @param integer  $flag   Event::READ or Event::WRITE
      */
     private function subscribeStreamEvent($stream, $flag)
     {
@@ -263,8 +263,8 @@ class ExtEventLoop implements LoopInterface
      * Update the ext-event Event object for this stream to stop listening to
      * the given event type, or remove it entirely if it's no longer needed.
      *
-     * @param stream  $stream
-     * @param integer $flag   Event::READ or Event::WRITE
+     * @param resource $stream
+     * @param integer  $flag   Event::READ or Event::WRITE
      */
     private function unsubscribeStreamEvent($stream, $flag)
     {

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -237,8 +237,8 @@ class LibEventLoop implements LoopInterface
     /**
      * Create a new ext-libevent event resource, or update the existing one.
      *
-     * @param stream  $stream
-     * @param integer $flag   EV_READ or EV_WRITE
+     * @param resource $stream
+     * @param integer  $flag   EV_READ or EV_WRITE
      */
     private function subscribeStreamEvent($stream, $flag)
     {
@@ -267,8 +267,8 @@ class LibEventLoop implements LoopInterface
      * Update the ext-libevent event resource for this stream to stop listening to
      * the given event type, or remove it entirely if it's no longer needed.
      *
-     * @param stream  $stream
-     * @param integer $flag   EV_READ or EV_WRITE
+     * @param resource $stream
+     * @param integer  $flag   EV_READ or EV_WRITE
      */
     private function unsubscribeStreamEvent($stream, $flag)
     {

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -9,7 +9,7 @@ interface LoopInterface
     /**
      * Register a listener to be notified when a stream is ready to read.
      *
-     * @param stream   $stream   The PHP stream resource to check.
+     * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
      */
     public function addReadStream($stream, callable $listener);
@@ -17,7 +17,7 @@ interface LoopInterface
     /**
      * Register a listener to be notified when a stream is ready to write.
      *
-     * @param stream   $stream   The PHP stream resource to check.
+     * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
      */
     public function addWriteStream($stream, callable $listener);
@@ -25,21 +25,21 @@ interface LoopInterface
     /**
      * Remove the read event listener for the given stream.
      *
-     * @param stream $stream The PHP stream resource.
+     * @param resource $stream The PHP stream resource.
      */
     public function removeReadStream($stream);
 
     /**
      * Remove the write event listener for the given stream.
      *
-     * @param stream $stream The PHP stream resource.
+     * @param resource $stream The PHP stream resource.
      */
     public function removeWriteStream($stream);
 
     /**
      * Remove all listeners for the given stream.
      *
-     * @param stream $stream The PHP stream resource.
+     * @param resource $stream The PHP stream resource.
      */
     public function removeStream($stream);
 
@@ -49,8 +49,8 @@ interface LoopInterface
      * The execution order of timers scheduled to execute at the same time is
      * not guaranteed.
      *
-     * @param numeric  $interval The number of seconds to wait before execution.
-     * @param callable $callback The callback to invoke.
+     * @param int|float $interval The number of seconds to wait before execution.
+     * @param callable  $callback The callback to invoke.
      *
      * @return TimerInterface
      */
@@ -62,8 +62,8 @@ interface LoopInterface
      * The execution order of timers scheduled to execute at the same time is
      * not guaranteed.
      *
-     * @param numeric  $interval The number of seconds to wait before execution.
-     * @param callable $callback The callback to invoke.
+     * @param int|float $interval The number of seconds to wait before execution.
+     * @param callable  $callback The callback to invoke.
      *
      * @return TimerInterface
      */

--- a/src/Timer/Timer.php
+++ b/src/Timer/Timer.php
@@ -14,6 +14,15 @@ class Timer implements TimerInterface
     protected $periodic;
     protected $data;
 
+    /**
+     * Constructor initializes the fields of the Timer
+     *
+     * @param LoopInterface $loop     The loop with which this timer is associated
+     * @param float         $interval The interval after which this timer will execute, in seconds
+     * @param callable      $callback The callback that will be executed when this timer elapses
+     * @param bool          $periodic Whether the time is periodic
+     * @param mixed         $data     Arbitrary data associated with timer
+     */
     public function __construct(LoopInterface $loop, $interval, callable $callback, $periodic = false, $data = null)
     {
         if ($interval < self::MIN_INTERVAL) {
@@ -27,41 +36,65 @@ class Timer implements TimerInterface
         $this->data = null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getLoop()
     {
         return $this->loop;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getInterval()
     {
         return $this->interval;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCallback()
     {
         return $this->callback;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setData($data)
     {
         $this->data = $data;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getData()
     {
         return $this->data;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isPeriodic()
     {
         return $this->periodic;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isActive()
     {
         return $this->loop->isTimerActive($this);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function cancel()
     {
         $this->loop->cancelTimer($this);

--- a/src/Timer/TimerInterface.php
+++ b/src/Timer/TimerInterface.php
@@ -2,14 +2,61 @@
 
 namespace React\EventLoop\Timer;
 
+use React\EventLoop\LoopInterface;
+
 interface TimerInterface
 {
+    /**
+     * Get the loop with which this timer is associated
+
+     * @return LoopInterface
+     */
     public function getLoop();
+
+    /**
+     * Get the interval after which this timer will execute, in seconds
+     *
+     * @return float
+     */
     public function getInterval();
+
+    /**
+     * Get the callback that will be executed when this timer elapses
+     *
+     * @return callable
+     */
     public function getCallback();
+
+    /**
+     * Set arbitrary data associated with timer
+     *
+     * @param mixed $data
+     */
     public function setData($data);
+
+    /**
+     * Get arbitrary data associated with timer
+     *
+     * @return mixed
+     */
     public function getData();
+
+    /**
+     * Determine whether the time is periodic
+     *
+     * @return bool
+     */
     public function isPeriodic();
+
+    /**
+     * Determine whether the time is active
+     *
+     * @return bool
+     */
     public function isActive();
+
+    /**
+     * Cancel this timer
+     */
     public function cancel();
 }


### PR DESCRIPTION
- Change `stream` and `numeric` hints to valid phpdoc internal types
- Add some docs to `TimerInterface` and `Timer`

I realise this falls largely into the category of IDE-driven development, but it shuts PHP Storm up a bit and I personally feel this is a positive change regardless of whether or not you use an IDE.
