### PR TITLE
[RFC] [WIP] API changes for enabling/disabling stream listeners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,33 +35,41 @@ All of the loops support these features:
 ## Usage
 
 Here is an async HTTP server built with just the event loop.
+
 ```php
-    $loop = React\EventLoop\Factory::create();
+$loop = React\EventLoop\Factory::create();
 
-    $server = stream_socket_server('tcp://127.0.0.1:8080');
-    stream_set_blocking($server, 0);
-    $loop->addReadStream($server, function ($server) use ($loop) {
-        $conn = stream_socket_accept($server);
-        $data = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nHi\n";
-        $loop->addWriteStream($conn, function ($conn) use (&$data, $loop) {
-            $written = fwrite($conn, $data);
-            if ($written === strlen($data)) {
-                fclose($conn);
-                $loop->removeStream($conn);
-            } else {
-                $data = substr($data, 0, $written);
-            }
-        });
+$server = stream_socket_server('tcp://127.0.0.1:8080');
+stream_set_blocking($server, 0);
+
+$loop->onReadable($server, function ($server, $loop) {
+    $conn = stream_socket_accept($server);
+    $data = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nHi\n";
+
+    $loop->onWritable($conn, function ($conn, $loop) use (&$data) {
+        $written = fwrite($conn, $data);
+        if ($written === strlen($data)) {
+            fclose($conn);
+            $loop->remove($conn);
+        } else {
+            $data = substr($data, 0, $written);
+        }
     });
 
-    $loop->addPeriodicTimer(5, function () {
-        $memory = memory_get_usage() / 1024;
-        $formatted = number_format($memory, 3).'K';
-        echo "Current memory usage: {$formatted}\n";
-    });
+    $loop->enableWrite($conn);
+});
 
-    $loop->run();
+$loop->enableRead($server);
+
+$loop->addPeriodicTimer(5, function () {
+    $memory = memory_get_usage() / 1024;
+    $formatted = number_format($memory, 3).'K';
+    echo "Current memory usage: {$formatted}\n";
+});
+
+$loop->run();
 ```
+
 **Note:** The factory is just for convenience. It tries to pick the best
 available implementation. Libraries `SHOULD` allow the user to inject an
 instance of the loop. They `MAY` use the factory when the user did not supply

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -164,7 +164,7 @@ class ExtEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function nextTick(callable $listener)
+    public function onNextTick(callable $listener)
     {
         $this->nextTickQueue->add($listener);
     }
@@ -172,7 +172,7 @@ class ExtEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function futureTick(callable $listener)
+    public function onFutureTick(callable $listener)
     {
         $this->futureTickQueue->add($listener);
     }

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -42,59 +42,67 @@ class ExtEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addReadStream($stream, callable $listener)
-    {
-        $key = (int) $stream;
-
-        if (!isset($this->readListeners[$key])) {
-            $this->readListeners[$key] = $listener;
-            $this->subscribeStreamEvent($stream, Event::READ);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addWriteStream($stream, callable $listener)
-    {
-        $key = (int) $stream;
-
-        if (!isset($this->writeListeners[$key])) {
-            $this->writeListeners[$key] = $listener;
-            $this->subscribeStreamEvent($stream, Event::WRITE);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeReadStream($stream)
+    public function onReadable($stream, callable $listener)
     {
         $key = (int) $stream;
 
         if (isset($this->readListeners[$key])) {
-            unset($this->readListeners[$key]);
-            $this->unsubscribeStreamEvent($stream, Event::READ);
+            throw new \RuntimeException(sprintf('Stream %s already has a read listener.', $key));
         }
+
+        $this->readListeners[$key] = $listener;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeWriteStream($stream)
+    public function enableRead($stream)
+    {
+        $this->subscribeStreamEvent($stream, Event::READ);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableRead($stream)
+    {
+        $this->unsubscribeStreamEvent($stream, Event::READ);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onWritable($stream, callable $listener)
     {
         $key = (int) $stream;
 
         if (isset($this->writeListeners[$key])) {
-            unset($this->writeListeners[$key]);
-            $this->unsubscribeStreamEvent($stream, Event::WRITE);
+            throw new \RuntimeException(sprintf('Stream %s already has a write listener.', $key));
         }
+
+        $this->writeListeners[$key] = $listener;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeStream($stream)
+    public function enableWrite($stream)
+    {
+        $this->subscribeStreamEvent($stream, Event::WRITE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableWrite($stream)
+    {
+        $this->unsubscribeStreamEvent($stream, Event::WRITE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($stream)
     {
         $key = (int) $stream;
 
@@ -273,7 +281,7 @@ class ExtEventLoop implements LoopInterface
         $flags = $this->streamFlags[$key] &= ~$flag;
 
         if (0 === $flags) {
-            $this->removeStream($stream);
+            $this->remove($stream);
 
             return;
         }

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -205,7 +205,7 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function nextTick(callable $listener)
+    public function onNextTick(callable $listener)
     {
         $this->nextTickQueue->add($listener);
     }
@@ -213,7 +213,7 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function futureTick(callable $listener)
+    public function onFutureTick(callable $listener)
     {
         $this->futureTickQueue->add($listener);
     }

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -21,6 +21,8 @@ class LibEvLoop implements LoopInterface
     private $nextTickQueue;
     private $futureTickQueue;
     private $timerEvents;
+    private $readListeners = [];
+    private $writeListeners = [];
     private $readEvents = [];
     private $writeEvents = [];
     private $running;
@@ -36,10 +38,28 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addReadStream($stream, callable $listener)
+    public function onReadable($stream, callable $listener)
     {
-        $callback = function () use ($stream, $listener) {
-            call_user_func($listener, $stream, $this);
+        $key = (int) $stream;
+
+        if (isset($this->readListeners[$key])) {
+            throw new \RuntimeException(sprintf('Stream %s already has a read listener.', $key));
+        }
+
+        $this->readListeners[$key] = $listener;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableRead($stream)
+    {
+        $callback = function () use ($stream) {
+            $key = (int) $stream;
+
+            if (isset($this->readListeners[$key])) {
+                call_user_func($this->readListeners[$key], $stream, $this);
+            }
         };
 
         $event = new IOEvent($callback, $stream, IOEvent::READ);
@@ -51,22 +71,7 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addWriteStream($stream, callable $listener)
-    {
-        $callback = function () use ($stream, $listener) {
-            call_user_func($listener, $stream, $this);
-        };
-
-        $event = new IOEvent($callback, $stream, IOEvent::WRITE);
-        $this->loop->add($event);
-
-        $this->writeEvents[(int) $stream] = $event;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeReadStream($stream)
+    public function disableRead($stream)
     {
         $key = (int) $stream;
 
@@ -79,7 +84,40 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeWriteStream($stream)
+    public function onWritable($stream, callable $listener)
+    {
+        $key = (int) $stream;
+
+        if (isset($this->writeListeners[$key])) {
+            throw new \RuntimeException(sprintf('Stream %s already has a write listener.', $key));
+        }
+
+        $this->writeListeners[$key] = $listener;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableWrite($stream)
+    {
+        $callback = function () use ($stream) {
+            $key = (int) $stream;
+
+            if (isset($this->writeListeners[$key])) {
+                call_user_func($this->writeListeners[$key], $stream, $this);
+            }
+        };
+
+        $event = new IOEvent($callback, $stream, IOEvent::WRITE);
+        $this->loop->add($event);
+
+        $this->writeEvents[(int) $stream] = $event;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableWrite($stream)
     {
         $key = (int) $stream;
 
@@ -92,10 +130,17 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeStream($stream)
+    public function remove($stream)
     {
-        $this->removeReadStream($stream);
-        $this->removeWriteStream($stream);
+        $this->disableRead($stream);
+        $this->disableWrite($stream);
+
+        $key = (int) $stream;
+
+        unset(
+            $this->readListeners[$key],
+            $this->writeListeners[$key]
+        );
     }
 
     /**

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -43,59 +43,67 @@ class LibEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addReadStream($stream, callable $listener)
-    {
-        $key = (int) $stream;
-
-        if (!isset($this->readListeners[$key])) {
-            $this->readListeners[$key] = $listener;
-            $this->subscribeStreamEvent($stream, EV_READ);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addWriteStream($stream, callable $listener)
-    {
-        $key = (int) $stream;
-
-        if (!isset($this->writeListeners[$key])) {
-            $this->writeListeners[$key] = $listener;
-            $this->subscribeStreamEvent($stream, EV_WRITE);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeReadStream($stream)
+    public function onReadable($stream, callable $listener)
     {
         $key = (int) $stream;
 
         if (isset($this->readListeners[$key])) {
-            unset($this->readListeners[$key]);
-            $this->unsubscribeStreamEvent($stream, EV_READ);
+            throw new \RuntimeException(sprintf('Stream %s already has a read listener.', $key));
         }
+
+        $this->readListeners[$key] = $listener;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeWriteStream($stream)
+    public function enableRead($stream)
+    {
+        $this->subscribeStreamEvent($stream, EV_READ);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableRead($stream)
+    {
+        $this->unsubscribeStreamEvent($stream, EV_READ);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onWritable($stream, callable $listener)
     {
         $key = (int) $stream;
 
         if (isset($this->writeListeners[$key])) {
-            unset($this->writeListeners[$key]);
-            $this->unsubscribeStreamEvent($stream, EV_WRITE);
+            throw new \RuntimeException(sprintf('Stream %s already has a write listener.', $key));
         }
+
+        $this->writeListeners[$key] = $listener;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeStream($stream)
+    public function enableWrite($stream)
+    {
+        $this->subscribeStreamEvent($stream, EV_WRITE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableWrite($stream)
+    {
+        $this->unsubscribeStreamEvent($stream, EV_WRITE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($stream)
     {
         $key = (int) $stream;
 
@@ -104,14 +112,14 @@ class LibEventLoop implements LoopInterface
 
             event_del($event);
             event_free($event);
-
-            unset(
-                $this->streamFlags[$key],
-                $this->streamEvents[$key],
-                $this->readListeners[$key],
-                $this->writeListeners[$key]
-            );
         }
+
+        unset(
+            $this->streamFlags[$key],
+            $this->streamEvents[$key],
+            $this->readListeners[$key],
+            $this->writeListeners[$key]
+        );
     }
 
     /**
@@ -277,7 +285,7 @@ class LibEventLoop implements LoopInterface
         $flags = $this->streamFlags[$key] &= ~$flag;
 
         if (0 === $flags) {
-            $this->removeStream($stream);
+            $this->remove($stream);
 
             return;
         }

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -172,7 +172,7 @@ class LibEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function nextTick(callable $listener)
+    public function onNextTick(callable $listener)
     {
         $this->nextTickQueue->add($listener);
     }
@@ -180,7 +180,7 @@ class LibEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function futureTick(callable $listener)
+    public function onFutureTick(callable $listener)
     {
         $this->futureTickQueue->add($listener);
     }

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -107,7 +107,7 @@ interface LoopInterface
      *
      * @param callable $listener The callback to invoke.
      */
-    public function nextTick(callable $listener);
+    public function onNextTick(callable $listener);
 
     /**
      * Schedule a callback to be invoked on a future tick of the event loop.
@@ -116,7 +116,7 @@ interface LoopInterface
      *
      * @param callable $listener The callback to invoke.
      */
-    public function futureTick(callable $listener);
+    public function onFutureTick(callable $listener);
 
     /**
      * Perform a single iteration of the event loop.

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -12,7 +12,21 @@ interface LoopInterface
      * @param stream   $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
      */
-    public function addReadStream($stream, callable $listener);
+    public function onReadable($stream, callable $listener);
+
+    /**
+     * Enables readable notifications when a stream is ready to write.
+     *
+     * @param stream $stream The PHP stream resource to check.
+     */
+    public function enableRead($stream);
+
+    /**
+     * Disables readable notifications when a stream is ready to write.
+     *
+     * @param stream $stream The PHP stream resource to check.
+     */
+    public function disableRead($stream);
 
     /**
      * Register a listener to be notified when a stream is ready to write.
@@ -20,28 +34,28 @@ interface LoopInterface
      * @param stream   $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
      */
-    public function addWriteStream($stream, callable $listener);
+    public function onWritable($stream, callable $listener);
 
     /**
-     * Remove the read event listener for the given stream.
+     * Enables writable notifications when a stream is ready to write.
      *
-     * @param stream $stream The PHP stream resource.
+     * @param stream $stream The PHP stream resource to check.
      */
-    public function removeReadStream($stream);
+    public function enableWrite($stream);
 
     /**
-     * Remove the write event listener for the given stream.
+     * Disables writable notifications when a stream is ready to write.
      *
-     * @param stream $stream The PHP stream resource.
+     * @param stream $stream The PHP stream resource to check.
      */
-    public function removeWriteStream($stream);
+    public function disableWrite($stream);
 
     /**
      * Remove all listeners for the given stream.
      *
      * @param stream $stream The PHP stream resource.
      */
-    public function removeStream($stream);
+    public function remove($stream);
 
     /**
      * Enqueue a callback to be invoked once after the given interval.

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -34,62 +34,80 @@ class StreamSelectLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addReadStream($stream, callable $listener)
+    public function onReadable($stream, callable $listener)
     {
         $key = (int) $stream;
 
-        if (!isset($this->readStreams[$key])) {
-            $this->readStreams[$key] = $stream;
-            $this->readListeners[$key] = $listener;
+        if (isset($this->readListeners[$key])) {
+            throw new \RuntimeException(sprintf('Stream %s already has a read listener.', $key));
         }
+
+        $this->readListeners[$key] = $listener;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addWriteStream($stream, callable $listener)
+    public function enableRead($stream)
     {
         $key = (int) $stream;
-
-        if (!isset($this->writeStreams[$key])) {
-            $this->writeStreams[$key] = $stream;
-            $this->writeListeners[$key] = $listener;
-        }
+        $this->readStreams[$key] = $stream;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeReadStream($stream)
+    public function disableRead($stream)
+    {
+        $key = (int) $stream;
+        unset($this->readStreams[$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onWritable($stream, callable $listener)
+    {
+        $key = (int) $stream;
+
+        if (isset($this->writeListeners[$key])) {
+            throw new \RuntimeException(sprintf('Stream %s already has a write listener.', $key));
+        }
+
+        $this->writeListeners[$key] = $listener;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableWrite($stream)
+    {
+        $key = (int) $stream;
+        $this->writeStreams[$key] = $stream;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableWrite($stream)
+    {
+        $key = (int) $stream;
+        unset($this->writeStreams[$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($stream)
     {
         $key = (int) $stream;
 
         unset(
             $this->readStreams[$key],
-            $this->readListeners[$key]
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeWriteStream($stream)
-    {
-        $key = (int) $stream;
-
-        unset(
+            $this->readListeners[$key],
             $this->writeStreams[$key],
             $this->writeListeners[$key]
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeStream($stream)
-    {
-        $this->removeReadStream($stream);
-        $this->removeWriteStream($stream);
     }
 
     /**

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -153,7 +153,7 @@ class StreamSelectLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function nextTick(callable $listener)
+    public function onNextTick(callable $listener)
     {
         $this->nextTickQueue->add($listener);
     }
@@ -161,7 +161,7 @@ class StreamSelectLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function futureTick(callable $listener)
+    public function onFutureTick(callable $listener)
     {
         $this->futureTickQueue->add($listener);
     }

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -223,7 +223,7 @@ abstract class AbstractLoopTest extends TestCase
             }
         );
 
-        $this->loop->nextTick(
+        $this->loop->onNextTick(
             function () {
                 $this->loop->stop();
             }
@@ -265,7 +265,7 @@ abstract class AbstractLoopTest extends TestCase
             $called = true;
         };
 
-        $this->loop->nextTick($callback);
+        $this->loop->onNextTick($callback);
 
         $this->assertFalse($called);
 
@@ -284,7 +284,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->enableWrite($stream);
 
-        $this->loop->nextTick(function () {
+        $this->loop->onNextTick(function () {
             echo 'next-tick' . PHP_EOL;
         });
 
@@ -303,8 +303,8 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->enableWrite($stream);
 
-        $this->loop->nextTick(function () {
-            $this->loop->nextTick(function () {
+        $this->loop->onNextTick(function () {
+            $this->loop->onNextTick(function () {
                 echo 'next-tick' . PHP_EOL;
             });
         });
@@ -320,7 +320,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->onWritable($stream, function () use ($stream) {
             $this->loop->remove($stream);
-            $this->loop->nextTick(function () {
+            $this->loop->onNextTick(function () {
                 echo 'next-tick' . PHP_EOL;
             });
         });
@@ -335,9 +335,9 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->futureTick(
+        $this->loop->onFutureTick(
             function () {
-                $this->loop->nextTick(
+                $this->loop->onNextTick(
                     function () {
                         echo 'next-tick' . PHP_EOL;
                     }
@@ -353,7 +353,7 @@ abstract class AbstractLoopTest extends TestCase
     public function testNextTickEventGeneratedByTimer()
     {
         $this->loop->addTimer(0.001, function () {
-            $this->loop->nextTick(function () {
+            $this->loop->onNextTick(function () {
                 echo 'next-tick' . PHP_EOL;
             });
         });
@@ -372,7 +372,7 @@ abstract class AbstractLoopTest extends TestCase
             $called = true;
         };
 
-        $this->loop->futureTick($callback);
+        $this->loop->onFutureTick($callback);
 
         $this->assertFalse($called);
 
@@ -394,7 +394,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->enableWrite($stream);
 
-        $this->loop->futureTick(
+        $this->loop->onFutureTick(
             function () {
                 echo 'future-tick' . PHP_EOL;
             }
@@ -419,10 +419,10 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->enableWrite($stream);
 
-        $this->loop->futureTick(
+        $this->loop->onFutureTick(
             function () {
                 echo 'future-tick-1' . PHP_EOL;
-                $this->loop->futureTick(
+                $this->loop->onFutureTick(
                     function () {
                         echo 'future-tick-2' . PHP_EOL;
                     }
@@ -443,7 +443,7 @@ abstract class AbstractLoopTest extends TestCase
             $stream,
             function () use ($stream) {
                 $this->loop->remove($stream);
-                $this->loop->futureTick(
+                $this->loop->onFutureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;
                     }
@@ -462,9 +462,9 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->nextTick(
+        $this->loop->onNextTick(
             function () {
-                $this->loop->futureTick(
+                $this->loop->onFutureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;
                     }
@@ -482,7 +482,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addTimer(
             0.001,
             function () {
-                $this->loop->futureTick(
+                $this->loop->onFutureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;
                     }

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -28,7 +28,8 @@ abstract class AbstractLoopTest extends TestCase
     {
         $input = $this->createStream();
 
-        $this->loop->addReadStream($input, $this->expectCallableExactly(2));
+        $this->loop->onReadable($input, $this->expectCallableExactly(2));
+        $this->loop->enableRead($input);
 
         $this->writeToStream($input, "foo\n");
         $this->loop->tick();
@@ -41,54 +42,92 @@ abstract class AbstractLoopTest extends TestCase
     {
         $input = $this->createStream();
 
-        $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
+        $this->loop->onWritable($input, $this->expectCallableExactly(2));
+        $this->loop->enableWrite($input);
         $this->loop->tick();
         $this->loop->tick();
     }
 
-    public function testRemoveReadStreamInstantly()
+    public function testDisableReadStreamInstantly()
     {
         $input = $this->createStream();
 
-        $this->loop->addReadStream($input, $this->expectCallableNever());
-        $this->loop->removeReadStream($input);
+        $this->loop->onReadable($input, $this->expectCallableNever());
+        $this->loop->enableRead($input);
+        $this->loop->disableRead($input);
 
         $this->writeToStream($input, "bar\n");
         $this->loop->tick();
     }
 
-    public function testRemoveReadStreamAfterReading()
+    public function testDisableReadStreamAfterReading()
     {
         $input = $this->createStream();
 
-        $this->loop->addReadStream($input, $this->expectCallableOnce());
+        $this->loop->onReadable($input, $this->expectCallableOnce());
+        $this->loop->enableRead($input);
 
         $this->writeToStream($input, "foo\n");
         $this->loop->tick();
 
-        $this->loop->removeReadStream($input);
+        $this->loop->disableRead($input);
 
         $this->writeToStream($input, "bar\n");
         $this->loop->tick();
     }
 
-    public function testRemoveWriteStreamInstantly()
+    public function testDisableWriteStreamInstantly()
     {
         $input = $this->createStream();
 
-        $this->loop->addWriteStream($input, $this->expectCallableNever());
-        $this->loop->removeWriteStream($input);
+        $this->loop->onWritable($input, $this->expectCallableNever());
+        $this->loop->enableWrite($input);
+        $this->loop->disableWrite($input);
         $this->loop->tick();
     }
 
-    public function testRemoveWriteStreamAfterWriting()
+    public function testDisableWriteStreamAfterWriting()
     {
         $input = $this->createStream();
 
-        $this->loop->addWriteStream($input, $this->expectCallableOnce());
+        $this->loop->onWritable($input, $this->expectCallableOnce());
+        $this->loop->enableWrite($input);
         $this->loop->tick();
 
-        $this->loop->removeWriteStream($input);
+        $this->loop->disableWrite($input);
+        $this->loop->tick();
+    }
+
+    public function testDisableStreamForReadOnly()
+    {
+        $input = $this->createStream();
+
+        $this->loop->onReadable($input, $this->expectCallableNever());
+        $this->loop->enableRead($input);
+
+        $this->loop->onWritable($input, $this->expectCallableOnce());
+        $this->loop->enableWrite($input);
+
+        $this->loop->disableRead($input);
+
+        $this->writeToStream($input, "foo\n");
+        $this->loop->tick();
+    }
+
+    public function testDisableStreamForWriteOnly()
+    {
+        $input = $this->createStream();
+
+        $this->writeToStream($input, "foo\n");
+
+        $this->loop->onReadable($input, $this->expectCallableOnce());
+        $this->loop->enableRead($input);
+
+        $this->loop->onWritable($input, $this->expectCallableNever());
+        $this->loop->enableWrite($input);
+
+        $this->loop->disableWrite($input);
+
         $this->loop->tick();
     }
 
@@ -96,63 +135,46 @@ abstract class AbstractLoopTest extends TestCase
     {
         $input = $this->createStream();
 
-        $this->loop->addReadStream($input, $this->expectCallableNever());
-        $this->loop->addWriteStream($input, $this->expectCallableNever());
-        $this->loop->removeStream($input);
+        $this->loop->onReadable($input, $this->expectCallableNever());
+        $this->loop->onWritable($input, $this->expectCallableNever());
+        $this->loop->remove($input);
 
         $this->writeToStream($input, "bar\n");
         $this->loop->tick();
     }
 
-    public function testRemoveStreamForReadOnly()
+    public function testRemoveStreamAfterActivity()
     {
         $input = $this->createStream();
 
-        $this->loop->addReadStream($input, $this->expectCallableNever());
-        $this->loop->addWriteStream($input, $this->expectCallableOnce());
-        $this->loop->removeReadStream($input);
+        $this->loop->onReadable($input, $this->expectCallableOnce());
+        $this->loop->enableRead($input);
 
-        $this->writeToStream($input, "foo\n");
-        $this->loop->tick();
-    }
-
-    public function testRemoveStreamForWriteOnly()
-    {
-        $input = $this->createStream();
-
-        $this->writeToStream($input, "foo\n");
-
-        $this->loop->addReadStream($input, $this->expectCallableOnce());
-        $this->loop->addWriteStream($input, $this->expectCallableNever());
-        $this->loop->removeWriteStream($input);
-
-        $this->loop->tick();
-    }
-
-    public function testRemoveStream()
-    {
-        $input = $this->createStream();
-
-        $this->loop->addReadStream($input, $this->expectCallableOnce());
-        $this->loop->addWriteStream($input, $this->expectCallableOnce());
+        $this->loop->onWritable($input, $this->expectCallableOnce());
+        $this->loop->enableWrite($input);
 
         $this->writeToStream($input, "bar\n");
         $this->loop->tick();
 
-        $this->loop->removeStream($input);
+        $this->loop->remove($input);
 
         $this->writeToStream($input, "bar\n");
         $this->loop->tick();
     }
 
-    public function testRemoveInvalid()
+    public function testToggleAndRemoveInvalid()
     {
+        // Toggle read or write notifications and remove a valid stream from the
+        // event loop that was never added in the first place
         $stream = $this->createStream();
 
-        // remove a valid stream from the event loop that was never added in the first place
-        $this->loop->removeReadStream($stream);
-        $this->loop->removeWriteStream($stream);
-        $this->loop->removeStream($stream);
+        $this->loop->enableWrite($stream);
+        $this->loop->enableRead($stream);
+
+        $this->loop->disableWrite($stream);
+        $this->loop->disableRead($stream);
+
+        $this->loop->remove($stream);
     }
 
     /** @test */
@@ -167,10 +189,11 @@ abstract class AbstractLoopTest extends TestCase
         $input = $this->createStream();
 
         $loop = $this->loop;
-        $this->loop->addReadStream($input, function ($stream) use ($loop) {
-            $loop->removeStream($stream);
+        $this->loop->onReadable($input, function ($stream, $loop) {
+            $loop->remove($stream);
         });
 
+        $this->loop->enableRead($input);
         $this->writeToStream($input, "foo\n");
 
         $this->assertRunFasterThan(0.005);
@@ -181,11 +204,11 @@ abstract class AbstractLoopTest extends TestCase
     {
         $input = $this->createStream();
 
-        $loop = $this->loop;
-        $this->loop->addReadStream($input, function ($stream) use ($loop) {
+        $this->loop->onReadable($input, function ($stream, $loop) {
             $loop->stop();
         });
 
+        $this->loop->enableRead($input);
         $this->writeToStream($input, "foo\n");
 
         $this->assertRunFasterThan(0.005);
@@ -215,20 +238,22 @@ abstract class AbstractLoopTest extends TestCase
         $stream1 = $this->createStream();
         $stream2 = $this->createStream();
 
-        $loop = $this->loop;
-        $loop->addReadStream($stream1, function ($stream) use ($loop, $stream2) {
+        $this->loop->onReadable($stream1, function ($stream, $loop) use ($stream2) {
             // stream1 is readable, remove stream2 as well => this will invalidate its callback
-            $loop->removeReadStream($stream);
-            $loop->removeReadStream($stream2);
+            $loop->remove($stream);
+            $loop->remove($stream2);
         });
 
         // this callback would have to be called as well, but the first stream already removed us
-        $loop->addReadStream($stream2, $this->expectCallableNever());
+        $this->loop->onReadable($stream2, $this->expectCallableNever());
+
+        $this->loop->enableRead($stream1);
+        $this->loop->enableRead($stream2);
 
         $this->writeToStream($stream1, "foo\n");
         $this->writeToStream($stream2, "foo\n");
 
-        $loop->run();
+        $this->loop->run();
     }
 
     public function testNextTick()
@@ -253,18 +278,15 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
-            $stream,
-            function () {
+        $this->loop->onWritable($stream, function () {
                 echo 'stream' . PHP_EOL;
-            }
-        );
+        });
 
-        $this->loop->nextTick(
-            function () {
-                echo 'next-tick' . PHP_EOL;
-            }
-        );
+        $this->loop->enableWrite($stream);
+
+        $this->loop->nextTick(function () {
+            echo 'next-tick' . PHP_EOL;
+        });
 
         $this->expectOutputString('next-tick' . PHP_EOL . 'stream' . PHP_EOL);
 
@@ -275,22 +297,17 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
-            $stream,
-            function () {
-                echo 'stream' . PHP_EOL;
-            }
-        );
+        $this->loop->onWritable($stream, function () {
+            echo 'stream' . PHP_EOL;
+        });
 
-        $this->loop->nextTick(
-            function () {
-                $this->loop->nextTick(
-                    function () {
-                        echo 'next-tick' . PHP_EOL;
-                    }
-                );
-            }
-        );
+        $this->loop->enableWrite($stream);
+
+        $this->loop->nextTick(function () {
+            $this->loop->nextTick(function () {
+                echo 'next-tick' . PHP_EOL;
+            });
+        });
 
         $this->expectOutputString('next-tick' . PHP_EOL . 'stream' . PHP_EOL);
 
@@ -301,18 +318,14 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
-            $stream,
-            function () use ($stream) {
-                $this->loop->removeStream($stream);
-                $this->loop->nextTick(
-                    function () {
-                        echo 'next-tick' . PHP_EOL;
-                    }
-                );
-            }
-        );
+        $this->loop->onWritable($stream, function () use ($stream) {
+            $this->loop->remove($stream);
+            $this->loop->nextTick(function () {
+                echo 'next-tick' . PHP_EOL;
+            });
+        });
 
+        $this->loop->enableWrite($stream);
         $this->expectOutputString('next-tick' . PHP_EOL);
 
         $this->loop->run();
@@ -339,16 +352,11 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testNextTickEventGeneratedByTimer()
     {
-        $this->loop->addTimer(
-            0.001,
-            function () {
-                $this->loop->nextTick(
-                    function () {
-                        echo 'next-tick' . PHP_EOL;
-                    }
-                );
-            }
-        );
+        $this->loop->addTimer(0.001, function () {
+            $this->loop->nextTick(function () {
+                echo 'next-tick' . PHP_EOL;
+            });
+        });
 
         $this->expectOutputString('next-tick' . PHP_EOL);
 
@@ -377,12 +385,14 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
+        $this->loop->onWritable(
             $stream,
             function () {
                 echo 'stream' . PHP_EOL;
             }
         );
+
+        $this->loop->enableWrite($stream);
 
         $this->loop->futureTick(
             function () {
@@ -399,13 +409,15 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
+        $this->loop->onWritable(
             $stream,
             function () use ($stream) {
                 echo 'stream' . PHP_EOL;
-                $this->loop->removeWriteStream($stream);
+                $this->loop->remove($stream);
             }
         );
+
+        $this->loop->enableWrite($stream);
 
         $this->loop->futureTick(
             function () {
@@ -427,10 +439,10 @@ abstract class AbstractLoopTest extends TestCase
     {
         $stream = $this->createStream();
 
-        $this->loop->addWriteStream(
+        $this->loop->onWritable(
             $stream,
             function () use ($stream) {
-                $this->loop->removeStream($stream);
+                $this->loop->remove($stream);
                 $this->loop->futureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;
@@ -438,6 +450,8 @@ abstract class AbstractLoopTest extends TestCase
                 );
             }
         );
+
+        $this->loop->enableWrite($stream);
 
         $this->expectOutputString('future-tick' . PHP_EOL);
 

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -75,7 +75,8 @@ class ExtEventLoopTest extends AbstractLoopTest
         fwrite($input, 'x');
         ftruncate($input, 0);
 
-        $this->loop->addReadStream($input, $this->expectCallableExactly(2));
+        $this->loop->onReadable($input, $this->expectCallableExactly(2));
+        $this->loop->enableRead($input);
 
         $this->writeToStream($input, "foo\n");
         $this->loop->tick();


### PR DESCRIPTION
This PR is a WIP and not meant to be merged as-is, instead we want to start discussing this prototype (initially proposed by @igorw a while back) that aims to provide a new API (BC ahead!!) offering an easier and less cumbersome way to enable and disable stream listeners, effectively providing a nice way to toggle read or write notifications for streams without having to re-add the callbacks to the event loop.

This is a just a basic example to partially show how it works in practice:

``` php
stream_set_blocking(STDOUT, 0);
stream_set_blocking(STDIN, 0);

$echo = null;
$loop = new React\EventLoop\StreamSelectLoop();

$loop->onWritable(STDOUT, function ($stream, $loop) use (&$echo) {
    if ($echo) {
        fwrite($stream, "JUST $echo??? SRSLY????".PHP_EOL);
    }

    fwrite($stream, "Write anything and press [ENTER]: ");

    $loop->disableWrite($stream);
    $loop->enableRead(STDIN);
});

$loop->onReadable(STDIN, function ($stream, $loop) use (&$echo) {
    $echo = rtrim(fread($stream, 128), PHP_EOL);

    $loop->disableRead($stream);
    $loop->enableWrite(STDOUT);
});

$loop->enableWrite(STDOUT);

$loop->run();
```

The current implementation, as the time of writing, provides just the basics for testing the new design of `React\EventLoop\LoopInterface` but it is likely there are some issues (e.g. enabling notifications for streams without an associated listener should throw an exception). The test suite has been simply adapted to the new API with no added test cases.

Share your thoughts please!

**NOTE:** this PR has been manually ported from reactphp/react#258 to include only the changes related to the event loop while updating parts of code affected by some radical changes introduced in the meanwhile in v0.4 and the current state of the master branch.
