### PR TITLE
check return value of stream_select

### DIFF
--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -218,8 +218,8 @@ class StreamSelectLoop implements LoopInterface
         $read  = $this->readStreams;
         $write = $this->writeStreams;
 
-        $n = $this->streamSelect($read, $write, $timeout);
-        if (false === $n) {
+        $available = $this->streamSelect($read, $write, $timeout);
+        if (false === $available) {
             // if a system call has been interrupted,
             // we cannot rely on it's outcome
             return;

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -218,7 +218,12 @@ class StreamSelectLoop implements LoopInterface
         $read  = $this->readStreams;
         $write = $this->writeStreams;
 
-        $this->streamSelect($read, $write, $timeout);
+        $n = $this->streamSelect($read, $write, $timeout);
+        if (false === $n) {
+            // if a system call has been interrupted,
+            // we cannot rely on it's outcome
+            return;
+        }
 
         foreach ($read as $stream) {
             $key = (int) $stream;


### PR DESCRIPTION
This change was already requested as part of https://github.com/reactphp/react/pull/297

In the current Implementation, the return value of stream_select is not checked at all. According to the [php documentation](http://php.net/manual/en/function.stream-select.php#refsect1-function.stream-select-returnvalues), a return value of `false` indicates that the underlying system call failed, e.g. due to a received signal. If thats the case, we cannot savely rely on the outcome of stream_select.

Unlike https://github.com/reactphp/react/pull/297, this PR does not supress any raised warning.