### PR TITLE
Fix for PHP 7 fatal error on duplicate parameter names in closures

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -294,7 +294,7 @@ class ExtEventLoop implements LoopInterface
      */
     private function createTimerCallback()
     {
-        $this->timerCallback = function ($_, $_, $timer) {
+        $this->timerCallback = function ($_, $__, $timer) {
             call_user_func($timer->getCallback(), $timer);
 
             if (!$timer->isPeriodic() && $this->isTimerActive($timer)) {

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -298,7 +298,7 @@ class LibEventLoop implements LoopInterface
      */
     private function createTimerCallback()
     {
-        $this->timerCallback = function ($_, $_, $timer) {
+        $this->timerCallback = function ($_, $__, $timer) {
             call_user_func($timer->getCallback(), $timer);
 
             // Timer already cancelled ...


### PR DESCRIPTION
PHP 7 does not like duplicate parameter names: https://3v4l.org/usQhl