### PR TITLE
Redefinition of parameter underscore fixed for PHP 7

### DIFF
--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -298,7 +298,7 @@ class LibEventLoop implements LoopInterface
      */
     private function createTimerCallback()
     {
-        $this->timerCallback = function ($_, $_, $timer) {
+        $this->timerCallback = function ($fd, $ev, $timer) {
             call_user_func($timer->getCallback(), $timer);
 
             // Timer already cancelled ...


### PR DESCRIPTION
PHP Fatal error: Redefinition of parameter $_ in LibEventLoop.php on line 301 with PHP 7.0.3