### PR TITLE
[WIP] Update .travis.yml for PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: hhvm
-    - php: hhvm-nightly
   fast_finish: true
 
 install: ./travis-init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ php:
   - 7.0
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true
-
 install: ./travis-init.sh
 
 script:

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -294,7 +294,7 @@ class ExtEventLoop implements LoopInterface
      */
     private function createTimerCallback()
     {
-        $this->timerCallback = function ($_, $_, $timer) {
+        $this->timerCallback = function ($_, $__, $timer) {
             call_user_func($timer->getCallback(), $timer);
 
             if (!$timer->isPeriodic() && $this->isTimerActive($timer)) {

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -298,7 +298,7 @@ class LibEventLoop implements LoopInterface
      */
     private function createTimerCallback()
     {
-        $this->timerCallback = function ($_, $_, $timer) {
+        $this->timerCallback = function ($_, $__, $timer) {
             call_user_func($timer->getCallback(), $timer);
 
             // Timer already cancelled ...

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -176,7 +176,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->writeToStream($input, "foo\n");
 
-        $this->assertRunFasterThan(0.005);
+        $this->assertRunFasterThan(0.015);
     }
 
     /** @test */
@@ -194,7 +194,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->assertRunFasterThan(0.005);
     }
 
-    public function testStopShouldPreventRunFromBlocking()
+    public function testStopShouldPreventRunFromBlocking($timeLimit = 0.005)
     {
         $this->loop->addTimer(
             1,
@@ -209,7 +209,7 @@ abstract class AbstractLoopTest extends TestCase
             }
         );
 
-        $this->assertRunFasterThan(0.005);
+        $this->assertRunFasterThan($timeLimit);
     }
 
     public function testIgnoreRemovedCallback()

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -37,6 +37,17 @@ class StreamSelectLoopTest extends AbstractLoopTest
         $this->assertGreaterThan(0.04, $interval);
     }
 
+    public function testStopShouldPreventRunFromBlocking($timeLimit = 0.005)
+    {
+        if (defined('HHVM_VERSION')) {
+            // HHVM is a bit slow, so give it more time
+            parent::testStopShouldPreventRunFromBlocking(0.5);
+        } else {
+            parent::testStopShouldPreventRunFromBlocking($timeLimit);
+        }
+    }
+
+
     public function signalProvider()
     {
         return [

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -11,25 +11,29 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     # install 'event' PHP extension
     echo "yes" | pecl install event
 
-    # install 'libevent' PHP extension
-    curl http://pecl.php.net/get/libevent-0.1.0.tgz | tar -xz
-    pushd libevent-0.1.0
-    phpize
-    ./configure
-    make
-    make install
-    popd
-    echo "extension=libevent.so" >> "$(php -r 'echo php_ini_loaded_file();')"
+    # install 'libevent' PHP extension (does not support php 7)
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+        curl http://pecl.php.net/get/libevent-0.1.0.tgz | tar -xz
+        pushd libevent-0.1.0
+        phpize
+       ./configure
+       make
+       make install
+       popd
+       echo "extension=libevent.so" >> "$(php -r 'echo php_ini_loaded_file();')"
+    fi
 
-    # install 'libev' PHP extension
-    git clone --recursive https://github.com/m4rw3r/php-libev
-    pushd php-libev
-    phpize
-    ./configure --with-libev
-    make
-    make install
-    popd
-    echo "extension=libev.so" >> "$(php -r 'echo php_ini_loaded_file();')"
+    # install 'libev' PHP extension (does not support php 7)
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+        git clone --recursive https://github.com/m4rw3r/php-libev
+        pushd php-libev
+        phpize
+        ./configure --with-libev
+        make
+        make install
+        popd
+        echo "extension=libev.so" >> "$(php -r 'echo php_ini_loaded_file();')"
+    fi
 
 fi
 


### PR DESCRIPTION
- there is no `hhvm-nightly` anymore on travis https://github.com/travis-ci/travis-ci/issues/3788#issuecomment-97171678
- add php 7
   - `event` extension works
   - `libev` does not support PHP 7 (yet?) https://github.com/m4rw3r/php-libev/issues/8
   - `libevent` also does not support PHP 7 https://pecl.php.net/package/libevent
- applied patch by @ondrejmirtes from #39 to make tests pass
