### PR TITLE
Cap min timer interval at 1µs, thus improving compatibility with v0.4

### DIFF
--- a/LibEventLoop.php
+++ b/LibEventLoop.php
@@ -8,6 +8,7 @@ use React\EventLoop\Timer\TimerInterface;
 
 class LibEventLoop implements LoopInterface
 {
+    /** @deprecated unused, left here for BC only */
     const MIN_TIMER_RESOLUTION = 0.001;
 
     private $base;
@@ -150,10 +151,6 @@ class LibEventLoop implements LoopInterface
 
     protected function addTimerInternal($interval, $callback, $periodic = false)
     {
-        if ($interval < self::MIN_TIMER_RESOLUTION) {
-            throw new \InvalidArgumentException('Timer events do not support sub-millisecond timeouts.');
-        }
-
         $timer = new Timer($this, $interval, $callback, $periodic);
         $resource = event_new();
 
@@ -174,7 +171,7 @@ class LibEventLoop implements LoopInterface
 
         event_timer_set($resource, $callback);
         event_base_set($resource, $this->base);
-        event_add($resource, $interval * 1000000);
+        event_add($resource, $timer->getInterval() * 1000000);
 
         return $timer;
     }

--- a/Timer/Timer.php
+++ b/Timer/Timer.php
@@ -7,6 +7,8 @@ use React\EventLoop\LoopInterface;
 
 class Timer implements TimerInterface
 {
+    const MIN_INTERVAL = 0.000001;
+
     protected $loop;
     protected $interval;
     protected $callback;
@@ -17,6 +19,10 @@ class Timer implements TimerInterface
     {
         if (false === is_callable($callback)) {
             throw new InvalidArgumentException('The callback argument must be a valid callable object');
+        }
+
+        if ($interval < self::MIN_INTERVAL) {
+            $interval = self::MIN_INTERVAL;
         }
 
         $this->loop = $loop;

--- a/Timer/Timers.php
+++ b/Timer/Timers.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 
 class Timers
 {
+    /** @deprecated unused, left here for BC only */
     const MIN_RESOLUTION = 0.001;
 
     private $time;
@@ -33,11 +34,6 @@ class Timers
     public function add(TimerInterface $timer)
     {
         $interval = $timer->getInterval();
-
-        if ($interval < self::MIN_RESOLUTION) {
-            throw new InvalidArgumentException('Timer events do not support sub-millisecond timeouts.');
-        }
-
         $scheduledAt = $interval + $this->getTime();
 
         $this->timers->attach($timer, $scheduledAt);


### PR DESCRIPTION
This change only aims to improve compatibility with v0.4 which already has the same behavior: https://github.com/reactphp/event-loop/blob/164799f73175e1c80bba92a220ea35df6ca371dd/src/Timer/Timer.php#L9

Currently (v0.3 only), when passing an interval smaller than 1ms, we will throw an `InvalidArgumentException`.

With this change applied, the minimum timer interval is capped at 1µs. This means that passing any smaller interval will still try to execute the timer in 1µs.

There are quite a few libraries that target both v0.3 and v0.4 of this component, so it makes sense to keep BC breaks between those versions to a minimum. I'll look into linking relevant tickets against this PR.

FWIW: No tests included because the v0.3 branch does not currently contain any tests unfortunately.
