### PR TITLE
Discourage libevent on PHP 7

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -7,12 +7,13 @@ class Factory
     public static function create()
     {
         // @codeCoverageIgnoreStart
-        if (function_exists('event_base_new')) {
-            return new LibEventLoop();
-        } elseif (class_exists('libev\EventLoop', false)) {
+        if (class_exists('libev\EventLoop', false)) {
             return new LibEvLoop;
         } elseif (class_exists('EventBase', false)) {
             return new ExtEventLoop;
+        } elseif (function_exists('event_base_new') && PHP_VERSION_ID < 70000) {
+            // only use ext-libevent on PHP < 7 for now
+            return new LibEventLoop();
         }
 
         return new StreamSelectLoop();

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -29,6 +29,10 @@ class LibEventLoop implements LoopInterface
 
     public function __construct()
     {
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            trigger_error('The libevent extension has not yet been updated for PHP 7, it is recommended you use a different loop', E_USER_WARNING);
+        }
+
         $this->eventBase = event_base_new();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -29,10 +29,6 @@ class LibEventLoop implements LoopInterface
 
     public function __construct()
     {
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
-            trigger_error('The libevent extension has not yet been updated for PHP 7, it is recommended you use a different loop', E_USER_WARNING);
-        }
-
         $this->eventBase = event_base_new();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();


### PR DESCRIPTION
The libevent extension has not been updated for PHP 7 and I have seen reports of segfaults as a result. 