### PR TITLE
Test suite now uses socket pairs instead of memory streams

### DIFF
--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -81,10 +81,10 @@ class ExtEventLoopTest extends AbstractLoopTest
 
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
 
-        $this->writeToStream($input, "foo\n");
+        fwrite($input, "foo\n");
         $this->loop->tick();
 
-        $this->writeToStream($input, "bar\n");
+        fwrite($input, "bar\n");
         $this->loop->tick();
     }
 }

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -88,7 +88,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
         $this->loop->addPeriodicTimer(0.01, function() { pcntl_signal_dispatch(); });
 
         // add stream to the loop
-        list($writeStream, $readStream) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        list($writeStream, $readStream) = $this->createSocketPair();
         $this->loop->addReadStream($readStream, function($stream, $loop) {
             /** @var $loop LoopInterface */
             $read = fgets($stream);


### PR DESCRIPTION
~~This PR contains 2 changes:~~

~~Warnings when using undefined signal constants in a PHPUnit data provider are avoided. Missing constants for signals are defined as needed in the abstract test case.~~

Streams used by test cases are created as connected socket pairs. Most event loop extension do not support arbitrary file descriptors but they all support socket pairs. The created socket pairs use unix domain sockets if they are available. The fallback to INET sockets is needed in order to support Windows.