### PR TITLE
StreamSelectLoop: Test suite uses signal constant names in data provider

### DIFF
--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -40,9 +40,9 @@ class StreamSelectLoopTest extends AbstractLoopTest
     public function signalProvider()
     {
         return [
-            ['SIGUSR1', SIGUSR1],
-            ['SIGHUP', SIGHUP],
-            ['SIGTERM', SIGTERM],
+            ['SIGUSR1'],
+            ['SIGHUP'],
+            ['SIGTERM'],
         ];
     }
 
@@ -52,7 +52,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
      * Test signal interrupt when no stream is attached to the loop
      * @dataProvider signalProvider
      */
-    public function testSignalInterruptNoStream($sigName, $signal)
+    public function testSignalInterruptNoStream($signal)
     {
         if (!extension_loaded('pcntl')) {
             $this->markTestSkipped('"pcntl" extension is required to run this test.');
@@ -78,7 +78,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
      * Test signal interrupt when a stream is attached to the loop
      * @dataProvider signalProvider
      */
-    public function testSignalInterruptWithStream($sigName, $signal)
+    public function testSignalInterruptWithStream($signal)
     {
         if (!extension_loaded('pcntl')) {
             $this->markTestSkipped('"pcntl" extension is required to run this test.');
@@ -116,7 +116,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
     protected function setUpSignalHandler($signal)
     {
         $this->_signalHandled = false;
-        $this->assertTrue(pcntl_signal($signal, function() { $this->_signalHandled = true; }));
+        $this->assertTrue(pcntl_signal(constant($signal), function() { $this->_signalHandled = true; }));
     }
 
     /**
@@ -125,7 +125,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
     protected function resetSignalHandlers()
     {
         foreach($this->signalProvider() as $signal) {
-            pcntl_signal($signal[1], SIG_DFL);
+            pcntl_signal(constant($signal[0]), SIG_DFL);
         }
     }
 
@@ -141,7 +141,7 @@ class StreamSelectLoopTest extends AbstractLoopTest
         } else if ($childPid === 0) {
             // this is executed in the child process
             usleep(20000);
-            posix_kill($currentPid, $signal);
+            posix_kill($currentPid, constant($signal));
             die();
         }
     }


### PR DESCRIPTION
Define constants `SIGUSR1`, `SIGHUP` and `SIGTERM` if they are not defined yet. The signal constants are used in data provider `StreamSelectLoopTest::signalProvider()` and cause a notice when the pcntl extension is not loaded.

```
Notice: Use of undefined constant SIGUSR1 - assumed 'SIGUSR1'
```