### PR TITLE
Avoid deprecation warnings in test suite due to deprecation of getMock() in PHPUnit

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,16 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function createCallableMock()
     {
-        return $this->getMock('React\Tests\EventLoop\CallableStub');
+        $stub = 'React\Tests\EventLoop\CallableStub';
+        
+        if (method_exists($this, 'createMock')) {
+            return $this->createMock($stub);
+        }
+        
+        if (method_exists($this, 'getMockBuilder')) {
+            return $this->getMockBuilder($stub)->getMock();
+        }
+        
+        return $this->getMock($stub);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,10 +42,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
             return $this->createMock($stub);
         }
         
-        if (method_exists($this, 'getMockBuilder')) {
-            return $this->getMockBuilder($stub)->getMock();
-        }
-        
         return $this->getMock($stub);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,12 +36,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function createCallableMock()
     {
-        $stub = 'React\Tests\EventLoop\CallableStub';
-        
-        if (method_exists($this, 'createMock')) {
-            return $this->createMock($stub);
-        }
-        
-        return $this->getMock($stub);
+        return $this->getMockBuilder('React\Tests\EventLoop\CallableStub')->getMock();
     }
 }


### PR DESCRIPTION
The method `getMock()` was deprecated with the [release of PHPUnit 5.4](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0). The same release introduced `createMock()` that should be used to create mock objects instead. This PR modifies `React\Tests\EventLoop\TestCase::createCallableMock()` to use the new mock API if available.