### PR TITLE
Drop tick() from LoopInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 (xxxx-xx-xx)
+
+* BC break: Remove `LoopInterface::tick()` (@jsor, #72)
+
 ## 0.4.2 (2016-03-07)
 
 * Bug fix: No longer error when signals sent to StreamSelectLoop

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -172,19 +172,6 @@ class ExtEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function tick()
-    {
-        $this->nextTickQueue->tick();
-
-        $this->futureTickQueue->tick();
-
-        // @-suppression: https://github.com/reactphp/react/pull/234#discussion-diff-7759616R226
-        @$this->eventBase->loop(EventBase::LOOP_ONCE | EventBase::LOOP_NONBLOCK);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function run()
     {
         $this->running = true;

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -176,18 +176,6 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function tick()
-    {
-        $this->nextTickQueue->tick();
-
-        $this->futureTickQueue->tick();
-
-        $this->loop->run(EventLoop::RUN_ONCE | EventLoop::RUN_NOWAIT);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function run()
     {
         $this->running = true;

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -180,18 +180,6 @@ class LibEventLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function tick()
-    {
-        $this->nextTickQueue->tick();
-
-        $this->futureTickQueue->tick();
-
-        event_base_loop($this->eventBase, EVLOOP_ONCE | EVLOOP_NONBLOCK);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function run()
     {
         $this->running = true;

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -105,11 +105,6 @@ interface LoopInterface
     public function futureTick(callable $listener);
 
     /**
-     * Perform a single iteration of the event loop.
-     */
-    public function tick();
-
-    /**
      * Run the event loop until there are no more tasks to perform.
      */
     public function run();

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -151,20 +151,6 @@ class StreamSelectLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function tick()
-    {
-        $this->nextTickQueue->tick();
-
-        $this->futureTickQueue->tick();
-
-        $this->timers->tick();
-
-        $this->waitForStreamActivity(0);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function run()
     {
         $this->running = true;

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -38,10 +38,10 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
 
         $this->writeToStream($input, "foo\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testAddWriteStream()
@@ -49,8 +49,8 @@ abstract class AbstractLoopTest extends TestCase
         $input = $this->createStream();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
-        $this->loop->tick();
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveReadStreamInstantly()
@@ -61,7 +61,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->removeReadStream($input);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveReadStreamAfterReading()
@@ -71,12 +71,12 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addReadStream($input, $this->expectCallableOnce());
 
         $this->writeToStream($input, "foo\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->loop->removeReadStream($input);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveWriteStreamInstantly()
@@ -85,7 +85,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->loop->addWriteStream($input, $this->expectCallableNever());
         $this->loop->removeWriteStream($input);
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveWriteStreamAfterWriting()
@@ -93,10 +93,10 @@ abstract class AbstractLoopTest extends TestCase
         $input = $this->createStream();
 
         $this->loop->addWriteStream($input, $this->expectCallableOnce());
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->loop->removeWriteStream($input);
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveStreamInstantly()
@@ -108,7 +108,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->removeStream($input);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveStreamForReadOnly()
@@ -120,7 +120,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->removeReadStream($input);
 
         $this->writeToStream($input, "foo\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveStreamForWriteOnly()
@@ -133,7 +133,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addWriteStream($input, $this->expectCallableNever());
         $this->loop->removeWriteStream($input);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveStream()
@@ -144,12 +144,12 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addWriteStream($input, $this->expectCallableOnce());
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->loop->removeStream($input);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRemoveInvalid()
@@ -251,7 +251,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->assertFalse($called);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->assertTrue($called);
     }
@@ -275,7 +275,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->expectOutputString('next-tick' . PHP_EOL . 'stream' . PHP_EOL);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRecursiveNextTick()
@@ -301,7 +301,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->expectOutputString('next-tick' . PHP_EOL . 'stream' . PHP_EOL);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRunWaitsForNextTickEvents()
@@ -375,7 +375,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->assertFalse($called);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->assertTrue($called);
     }
@@ -399,7 +399,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $this->expectOutputString('future-tick' . PHP_EOL . 'stream' . PHP_EOL);
 
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 
     public function testRecursiveFutureTick()

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -82,9 +82,9 @@ class ExtEventLoopTest extends AbstractLoopTest
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
 
         $this->writeToStream($input, "foo\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
 
         $this->writeToStream($input, "bar\n");
-        $this->loop->tick();
+        $this->tickLoop($this->loop);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace React\Tests\EventLoop;
 
+use React\EventLoop\LoopInterface;
+
 class TestCase extends \PHPUnit_Framework_TestCase
 {
     protected function expectCallableExactly($amount)
@@ -37,5 +39,14 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function createCallableMock()
     {
         return $this->getMockBuilder('React\Tests\EventLoop\CallableStub')->getMock();
+    }
+
+    protected function tickLoop(LoopInterface $loop)
+    {
+        $loop->futureTick(function () use ($loop) {
+            $loop->stop();
+        });
+
+        $loop->run();
     }
 }

--- a/tests/Timer/AbstractTimerTest.php
+++ b/tests/Timer/AbstractTimerTest.php
@@ -16,7 +16,7 @@ abstract class AbstractTimerTest extends TestCase
 
         $loop->addTimer(0.001, $this->expectCallableOnce());
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
     }
 
     public function testAddPeriodicTimer()
@@ -25,11 +25,11 @@ abstract class AbstractTimerTest extends TestCase
 
         $loop->addPeriodicTimer(0.001, $this->expectCallableExactly(3));
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
     }
 
     public function testAddPeriodicTimerWithCancel()
@@ -39,14 +39,14 @@ abstract class AbstractTimerTest extends TestCase
         $timer = $loop->addPeriodicTimer(0.001, $this->expectCallableExactly(2));
 
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
 
         $timer->cancel();
 
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
     }
 
     public function testAddPeriodicTimerCancelsItself()
@@ -64,11 +64,11 @@ abstract class AbstractTimerTest extends TestCase
         });
 
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
         usleep(1000);
-        $loop->tick();
+        $this->tickLoop($loop);
 
         $this->assertSame(2, $i);
     }


### PR DESCRIPTION
References: https://github.com/reactphp/event-loop/pull/52#issuecomment-239688446, async-interop/event-loop#9

For the tests, i've added a [helper function](https://github.com/reactphp/event-loop/pull/72/files#diff-d4c8c6dc8769324fc27cfdac19f05cafR44) to `TestCase`.

Closes #52 