### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ addons:
     packages:
       - libevent-dev # Used by 'event' and 'libevent' PHP extensions
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - ./travis-init.sh
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 install:
   - ./travis-init.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ php:
   - 7.0
   - hhvm
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libevent-dev # Used by 'event' and 'libevent' PHP extensions
+
 install:
   - ./travis-init.sh
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ php:
   - 7.0
   - hhvm
 
-install: ./travis-init.sh
+install:
+  - ./travis-init.sh
+  - composer install
 
 script:
   - ./vendor/bin/phpunit --coverage-text

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -37,4 +37,4 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
 
 fi
 
-composer install --prefer-source
+composer install

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -36,5 +36,3 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     fi
 
 fi
-
-composer install

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -9,7 +9,8 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     echo "yes" | pecl install event
 
     # install 'libevent' PHP extension (does not support php 7)
-    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" &&
+          "$TRAVIS_PHP_VERSION" != "7.1" ]]; then
         curl http://pecl.php.net/get/libevent-0.1.0.tgz | tar -xz
         pushd libevent-0.1.0
         phpize
@@ -21,7 +22,8 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     fi
 
     # install 'libev' PHP extension (does not support php 7)
-    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" &&
+          "$TRAVIS_PHP_VERSION" != "7.1" ]]; then
         git clone --recursive https://github.com/m4rw3r/php-libev
         pushd php-libev
         phpize

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -5,9 +5,6 @@ set -o pipefail
 if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
       "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
 
-    # install "libevent" (used by 'event' and 'libevent' PHP extensions)
-    sudo apt-get install -y libevent-dev
-
     # install 'event' PHP extension
     echo "yes" | pecl install event
 

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -37,4 +37,4 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
 
 fi
 
-composer install --dev --prefer-source
+composer install --prefer-source


### PR DESCRIPTION
Main changes are:

* Enabled running tests on travis' container based infrastructure

  This solves that tests can now be run for forks which default to the container based infrastructure when created after 2015.

  Refs:
  * https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
  * See eg. https://travis-ci.org/jsor/event-loop/jobs/198781026#L158, builds are failing here
* `composer install`
  * Moved from travis-init.sh to .travis.yml
  * Removed deprecated `--dev` option
  * Removed `--prefer-source` not longer required to prevent rate limit issues, see https://github.com/composer/composer/issues/4884#issuecomment-195229989
* Run tests on PHP 7.1