### PR TITLE
Travis improvements (backported from #74)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,23 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
-install: ./travis-init.sh
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libevent-dev # Used by 'event' and 'libevent' PHP extensions
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+install:
+  - ./travis-init.sh
+  - composer install
 
 script:
   - ./vendor/bin/phpunit --coverage-text

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -5,14 +5,12 @@ set -o pipefail
 if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
       "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
 
-    # install "libevent" (used by 'event' and 'libevent' PHP extensions)
-    sudo apt-get install -y libevent-dev
-
     # install 'event' PHP extension
     echo "yes" | pecl install event
 
     # install 'libevent' PHP extension (does not support php 7)
-    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" &&
+          "$TRAVIS_PHP_VERSION" != "7.1" ]]; then
         curl http://pecl.php.net/get/libevent-0.1.0.tgz | tar -xz
         pushd libevent-0.1.0
         phpize
@@ -24,7 +22,8 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     fi
 
     # install 'libev' PHP extension (does not support php 7)
-    if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" != "7.0" &&
+          "$TRAVIS_PHP_VERSION" != "7.1" ]]; then
         git clone --recursive https://github.com/m4rw3r/php-libev
         pushd php-libev
         phpize
@@ -36,5 +35,3 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     fi
 
 fi
-
-composer install --dev --prefer-source


### PR DESCRIPTION
This contains all changes from #74 by @jsor squashed into a single commit for the 0.4 release branch:

* Remove deprecated --dev option from composer install
* Remove --prefer-source from composer install
* Move composer install to .travis.yml
* Enable container based infrastructure on travis
* Enable travis cache
* Add PHP 7.1 to test matrix
* Adjust composer cache directory to only cache package files