### PR TITLE
[RFC] Global Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,4 @@ Here is an async HTTP server built with just the event loop.
         $formatted = number_format($memory, 3).'K';
         echo "Current memory usage: {$formatted}\n";
     });
-
-    React\EventLoop\run();
 ```

--- a/README.md
+++ b/README.md
@@ -40,33 +40,27 @@ All of the loops support these features:
 
 Here is an async HTTP server built with just the event loop.
 ```php
-    $loop = React\EventLoop\Factory::create();
-
     $server = stream_socket_server('tcp://127.0.0.1:8080');
     stream_set_blocking($server, 0);
-    $loop->addReadStream($server, function ($server) use ($loop) {
+    React\EventLoop\addReadStream($server, function ($server) {
         $conn = stream_socket_accept($server);
         $data = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nHi\n";
-        $loop->addWriteStream($conn, function ($conn) use (&$data, $loop) {
+        React\EventLoop\addWriteStream($conn, function ($conn) use (&$data) {
             $written = fwrite($conn, $data);
             if ($written === strlen($data)) {
                 fclose($conn);
-                $loop->removeStream($conn);
+                React\EventLoop\removeStream($conn);
             } else {
                 $data = substr($data, $written);
             }
         });
     });
 
-    $loop->addPeriodicTimer(5, function () {
+    React\EventLoop\addPeriodicTimer(5, function () {
         $memory = memory_get_usage() / 1024;
         $formatted = number_format($memory, 3).'K';
         echo "Current memory usage: {$formatted}\n";
     });
 
-    $loop->run();
+    React\EventLoop\run();
 ```
-**Note:** The factory is just for convenience. It tries to pick the best
-available implementation. Libraries `SHOULD` allow the user to inject an
-instance of the loop. They `MAY` use the factory when the user did not supply
-a loop.

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "autoload": {
         "psr-4": {
             "React\\EventLoop\\": "src"
-        }
+        },
+        "files": ["src/functions.php"]
     }
 }

--- a/src/GlobalLoop.php
+++ b/src/GlobalLoop.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace React\EventLoop;
+
+final class GlobalLoop
+{
+    /**
+     * @internal
+     *
+     * @var LoopInterface
+     */
+    public static $loop;
+
+    private static $factory = ['React\EventLoop\Factory', 'create'];
+
+    public static function setFactory(callable $factory)
+    {
+        if (self::$loop) {
+            throw new \LogicException(
+                'Setting a factory after the global loop has been created is not allowed.'
+            );
+        }
+
+        self::$factory = $factory;
+    }
+
+    /**
+     * @return LoopInterface
+     */
+    public static function get()
+    {
+        if (self::$loop) {
+            return self::$loop;
+        }
+
+        return self::$loop = self::create();
+    }
+
+    /**
+     * @return LoopInterface
+     */
+    public static function create()
+    {
+        $loop = call_user_func(self::$factory);
+
+        if (!$loop instanceof LoopInterface) {
+            throw new \LogicException(
+                sprintf(
+                    'The GlobalLoop factory must return an instance of LoopInterface but returned %s.',
+                    is_object($loop) ? get_class($loop) : gettype($loop)
+                )
+            );
+        }
+
+        return $loop;
+    }
+}

--- a/src/GlobalLoop.php
+++ b/src/GlobalLoop.php
@@ -13,6 +13,8 @@ final class GlobalLoop
 
     private static $factory = ['React\EventLoop\Factory', 'create'];
 
+    private static $disableRunOnShutdown = false;
+
     public static function setFactory(callable $factory)
     {
         if (self::$loop) {
@@ -24,6 +26,11 @@ final class GlobalLoop
         self::$factory = $factory;
     }
 
+    public function disableRunOnShutdown()
+    {
+        self::$disableRunOnShutdown = true;
+    }
+
     /**
      * @return LoopInterface
      */
@@ -32,6 +39,14 @@ final class GlobalLoop
         if (self::$loop) {
             return self::$loop;
         }
+
+        register_shutdown_function(function () {
+            if (self::$disableRunOnShutdown || !self::$loop) {
+                return;
+            }
+
+            self::$loop->run();
+        });
 
         return self::$loop = self::create();
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace React\EventLoop;
+
+use React\EventLoop\Timer\TimerInterface;
+
+/**
+ * Register a listener to the global event loop to be notified when a stream is
+ * ready to read.
+ *
+ * @param resource $stream   The PHP stream resource to check.
+ * @param callable $listener Invoked when the stream is ready.
+ */
+function addReadStream($stream, callable $listener)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->addReadStream($stream, $listener);
+}
+
+/**
+ * Register a listener to the global event loop to be notified when a stream is
+ * ready to write.
+ *
+ * @param resource $stream   The PHP stream resource to check.
+ * @param callable $listener Invoked when the stream is ready.
+ */
+function addWriteStream($stream, callable $listener)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->addWriteStream($stream, $listener);
+}
+
+/**
+ * Remove the read event listener from the global event loop for the given
+ * stream.
+ *
+ * @param resource $stream The PHP stream resource.
+ */
+function removeReadStream($stream)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->removeReadStream($stream);
+}
+
+/**
+ * Remove the write event listener from the global event loop for the given
+ * stream.
+ *
+ * @param resource $stream The PHP stream resource.
+ */
+function removeWriteStream($stream)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->removeWriteStream($stream);
+}
+
+/**
+ * Remove all listeners from the global event loop for the given stream.
+ *
+ * @param resource $stream The PHP stream resource.
+ */
+function removeStream($stream)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->removeStream($stream);
+}
+
+/**
+ * Enqueue a callback to the global event loop to be invoked once after the
+ * given interval.
+ *
+ * The execution order of timers scheduled to execute at the same time is
+ * not guaranteed.
+ *
+ * @param int|float $interval The number of seconds to wait before execution.
+ * @param callable  $callback The callback to invoke.
+ *
+ * @return TimerInterface
+ */
+function addTimer($interval, callable $callback)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    return $loop->addTimer($interval, $callback);
+}
+
+/**
+ * Enqueue a callback to the global event loop to be invoked repeatedly after
+ * the given interval.
+ *
+ * The execution order of timers scheduled to execute at the same time is
+ * not guaranteed.
+ *
+ * @param int|float $interval The number of seconds to wait before execution.
+ * @param callable  $callback The callback to invoke.
+ *
+ * @return TimerInterface
+ */
+function addPeriodicTimer($interval, callable $callback)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    return $loop->addPeriodicTimer($interval, $callback);
+}
+
+/**
+ * Schedule a callback to be invoked on a future tick of the global event loop.
+ *
+ * Callbacks are guaranteed to be executed in the order they are enqueued.
+ *
+ * @param callable $listener The callback to invoke.
+ */
+function futureTick(callable $listener)
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->futureTick($listener);
+}
+
+/**
+ * Run the global event loop until there are no more tasks to perform.
+ */
+function run()
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->run();
+}
+
+/**
+ * Instruct the running global event loop to stop.
+ */
+function stop()
+{
+    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
+
+    $loop->stop();
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -121,23 +121,3 @@ function futureTick(callable $listener)
 
     $loop->futureTick($listener);
 }
-
-/**
- * Run the global event loop until there are no more tasks to perform.
- */
-function run()
-{
-    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
-
-    $loop->run();
-}
-
-/**
- * Instruct the running global event loop to stop.
- */
-function stop()
-{
-    $loop = GlobalLoop::$loop ?: GlobalLoop::get();
-
-    $loop->stop();
-}

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace React\Tests\EventLoop;
+
+use React\EventLoop;
+use React\EventLoop\GlobalLoop;
+
+class FunctionTest extends TestCase
+{
+    private static $state;
+    private $globalLoop;
+
+    public function setUp()
+    {
+        $globalLoop = $this->getMockBuilder('React\EventLoop\LoopInterface')
+            ->getMock();
+
+        self::$state = GlobalLoop::$loop;
+        GlobalLoop::$loop = $this->globalLoop = $globalLoop;
+    }
+
+    public function tearDown()
+    {
+        $this->globalLoop = null;
+
+        GlobalLoop::$loop = self::$state;
+    }
+
+    public function createStream()
+    {
+        return fopen('php://temp', 'r+');
+    }
+
+    public function testAddReadStream()
+    {
+        $stream = $this->createStream();
+        $listener = function() {};
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('addReadStream')
+            ->with($stream, $listener);
+
+        EventLoop\addReadStream($stream, $listener);
+    }
+
+    public function testAddWriteStream()
+    {
+        $stream = $this->createStream();
+        $listener = function() {};
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('addWriteStream')
+            ->with($stream, $listener);
+
+        EventLoop\addWriteStream($stream, $listener);
+    }
+
+    public function testRemoveReadStream()
+    {
+        $stream = $this->createStream();
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('removeReadStream')
+            ->with($stream);
+
+        EventLoop\removeReadStream($stream);
+    }
+
+    public function testRemoveWriteStream()
+    {
+        $stream = $this->createStream();
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('removeWriteStream')
+            ->with($stream);
+
+        EventLoop\removeWriteStream($stream);
+    }
+
+    public function testRemoveStream()
+    {
+        $stream = $this->createStream();
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('removeStream')
+            ->with($stream);
+
+        EventLoop\removeStream($stream);
+    }
+
+    public function testAddTimer()
+    {
+        $interval = 1;
+        $listener = function() {};
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('addTimer')
+            ->with($interval, $listener);
+
+        EventLoop\addTimer($interval, $listener);
+    }
+
+    public function testAddPeriodicTimer()
+    {
+        $interval = 1;
+        $listener = function() {};
+
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('addPeriodicTimer')
+            ->with($interval, $listener);
+
+        EventLoop\addPeriodicTimer($interval, $listener);
+    }
+
+    public function testRun()
+    {
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('run');
+
+        EventLoop\run();
+    }
+
+    public function testStop()
+    {
+        $this->globalLoop
+            ->expects($this->once())
+            ->method('stop');
+
+        EventLoop\stop();
+    }
+}

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -118,22 +118,4 @@ class FunctionTest extends TestCase
 
         EventLoop\addPeriodicTimer($interval, $listener);
     }
-
-    public function testRun()
-    {
-        $this->globalLoop
-            ->expects($this->once())
-            ->method('run');
-
-        EventLoop\run();
-    }
-
-    public function testStop()
-    {
-        $this->globalLoop
-            ->expects($this->once())
-            ->method('stop');
-
-        EventLoop\stop();
-    }
 }

--- a/tests/GlobalLoopTest.php
+++ b/tests/GlobalLoopTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace React\Tests\EventLoop;
+
+use React\EventLoop\GlobalLoop;
+
+class GlobalLoopTest extends TestCase
+{
+    private static $state;
+
+    public function setUp()
+    {
+        self::$state = GlobalLoop::$loop;
+        GlobalLoop::$loop = null;
+    }
+
+    public function tearDown()
+    {
+        GlobalLoop::$loop = self::$state;
+        GlobalLoop::setFactory(['React\EventLoop\Factory', 'create']);
+    }
+
+    public function testCreatesDefaultLoop()
+    {
+        $this->assertNull(GlobalLoop::$loop);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', GlobalLoop::get());
+    }
+
+    public function testCreatesCustomLoopWithFactory()
+    {
+        $this->assertNull(GlobalLoop::$loop);
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')
+            ->getMock();
+
+        $factory = $this->createCallableMock();
+        $factory
+            ->expects($this->once())
+            ->method('__invoke')
+            ->will($this->returnValue($loop));
+
+        GlobalLoop::setFactory($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', GlobalLoop::get());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The GlobalLoop factory must return an instance of LoopInterface but returned NULL.
+     */
+    public function testThrowsExceptionWhenFactoryDoesNotReturnALoopInterface()
+    {
+        $this->assertNull(GlobalLoop::$loop);
+
+        $factory = $this->createCallableMock();
+        $factory
+            ->expects($this->once())
+            ->method('__invoke');
+
+        GlobalLoop::setFactory($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', GlobalLoop::get());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Setting a factory after the global loop has been created is not allowed.
+     */
+    public function testThrowsExceptionWhenSettingAFactoryAfterLoopIsCreated()
+    {
+        $this->assertNull(GlobalLoop::$loop);
+
+        GlobalLoop::get();
+
+        $this->assertNotNull(GlobalLoop::$loop);
+
+        GlobalLoop::setFactory($this->expectCallableNever());
+    }
+}


### PR DESCRIPTION
This is an alternative to #10 introducing a global loop on top of the current API and being backward compatible.

It adds a new API via functions on top of the current API for accessing the methods of the global loop (except `run()` and `stop`).

```php
React\EventLoop\futureTick(function() {
});
```

This allows components to also introduce their own functions on top of their existing API using the global loop.

```php
namespace React\Dns;

use React\EventLoop;

function resolver($nameserver)
{
    $factory = new React\Dns\Resolver\Factory();
    return $factory->create($nameserver, EventLoop\GlobalLoop::get());
}
```

By default, the driver is created by `Factory::create()`. This can be overridden by setting a custom factory using `GlobalLoop::setFactory()` which expects a simple `callable` returning a `LoopInterface`.

The global loop is run automatically in a shutdown function, so no need to call `run()` manually. This behaviour can be disabled by calling `GlobalLoop::disableRunOnShutdown()`.

This is a RFC, so share your thoughts and comments :)