### PR TITLE
[RFC] Global Loop (simplified)

### DIFF
--- a/src/GlobalLoop.php
+++ b/src/GlobalLoop.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace React\EventLoop;
+
+final class GlobalLoop
+{
+    /**
+     * @var LoopInterface
+     */
+    private static $loop;
+
+    private static $factory;
+
+    private static $didRun = false;
+
+    public static function setFactory(callable $factory = null)
+    {
+        if (self::$didRun) {
+            throw new \LogicException(
+                'Setting a factory after the global loop has been started is not allowed.'
+            );
+        }
+
+        self::$factory = $factory;
+    }
+
+    /**
+     * @return LoopInterface
+     */
+    public static function get()
+    {
+        if (self::$loop) {
+            return self::$loop;
+        }
+
+        self::$loop = self::create();
+
+        self::$loop->futureTick(function () {
+            self::$didRun = true;
+        });
+
+        return self::$loop;
+    }
+
+    public static function reset()
+    {
+        self::$loop = null;
+        self::$didRun = false;
+    }
+
+    /**
+     * @return LoopInterface
+     */
+    public static function create()
+    {
+        if (self::$factory) {
+            return self::createFromCustomFactory(self::$factory);
+        }
+
+        return Factory::create();
+    }
+
+    private static function createFromCustomFactory(callable $factory)
+    {
+        $loop = call_user_func($factory);
+
+        if (!$loop instanceof LoopInterface) {
+            throw new \LogicException(
+                sprintf(
+                    'The GlobalLoop factory must return an instance of LoopInterface but returned %s.',
+                    is_object($loop) ? get_class($loop) : gettype($loop)
+                )
+            );
+        }
+
+        return $loop;
+    }
+}

--- a/src/GlobalLoop.php
+++ b/src/GlobalLoop.php
@@ -12,6 +12,7 @@ final class GlobalLoop
     private static $factory;
 
     private static $didRun = false;
+    private static $disableRunOnShutdown = false;
 
     public static function setFactory(callable $factory = null)
     {
@@ -24,6 +25,11 @@ final class GlobalLoop
         self::$factory = $factory;
     }
 
+    public function disableRunOnShutdown()
+    {
+        self::$disableRunOnShutdown = true;
+    }
+
     /**
      * @return LoopInterface
      */
@@ -32,6 +38,14 @@ final class GlobalLoop
         if (self::$loop) {
             return self::$loop;
         }
+
+        register_shutdown_function(function () {
+            if (self::$disableRunOnShutdown || self::$didRun || !self::$loop) {
+                return;
+            }
+
+            self::$loop->run();
+        });
 
         self::$loop = self::create();
 

--- a/tests/GlobalLoopTest.php
+++ b/tests/GlobalLoopTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace React\Tests\EventLoop;
+
+use React\EventLoop\GlobalLoop;
+
+class GlobalLoopTest extends TestCase
+{
+    public function tearDown()
+    {
+        GlobalLoop::reset();
+        GlobalLoop::setFactory(null);
+    }
+
+    public function testCreatesDefaultLoop()
+    {
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', GlobalLoop::get());
+    }
+
+    public function testSubsequentGetCallsReturnSameInstance()
+    {
+        $this->assertSame(GlobalLoop::get(), GlobalLoop::get());
+    }
+
+    public function testSubsequentGetCallsReturnNotSameInstanceWhenResetting()
+    {
+        $loop = GlobalLoop::get();
+
+        GlobalLoop::reset();
+
+        $this->assertNotSame($loop, GlobalLoop::get());
+    }
+
+    public function testCreatesLoopWithFactory()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')
+            ->getMock();
+
+        $factory = $this->createCallableMock();
+        $factory
+            ->expects($this->once())
+            ->method('__invoke')
+            ->will($this->returnValue($loop));
+
+        GlobalLoop::setFactory($factory);
+
+        $this->assertSame($loop, GlobalLoop::get());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The GlobalLoop factory must return an instance of LoopInterface but returned NULL.
+     */
+    public function testThrowsExceptionWhenFactoryDoesNotReturnALoopInterface()
+    {
+        $factory = $this->createCallableMock();
+        $factory
+            ->expects($this->once())
+            ->method('__invoke');
+
+        GlobalLoop::setFactory($factory);
+
+        GlobalLoop::get();
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Setting a factory after the global loop has been started is not allowed.
+     */
+    public function testThrowsExceptionWhenSettingAFactoryAfterLoopIsCreated()
+    {
+        GlobalLoop::get()->run();
+
+        GlobalLoop::setFactory(null);
+    }
+}


### PR DESCRIPTION
This is a simplified alternative to #77 introducing a global loop on top of the current API and being backward compatible.

To use the global loop, `Factory::create()` can be simply replaced by `GlobalLoop::get()`.

The global loop is run automatically in a shutdown function, so no need to call `run()` manually. This behaviour can be disabled by calling `GlobalLoop::disableRunOnShutdown()` or by simply calling `GlobalLoop::get()->run()` .

This incorporates the suggestion from @mbonneau (https://github.com/reactphp/event-loop/pull/77#issuecomment-279186122) and also addresses https://github.com/reactphp/event-loop/pull/77#issuecomment-282234913.