### PR TITLE
Add tests for double watchers to be ignored

### DIFF
--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -38,6 +38,10 @@ class LibEvLoop implements LoopInterface
      */
     public function addReadStream($stream, callable $listener)
     {
+        if (isset($this->readEvents[(int) $stream])) {
+            return;
+        }
+
         $callback = function () use ($stream, $listener) {
             call_user_func($listener, $stream, $this);
         };
@@ -53,6 +57,10 @@ class LibEvLoop implements LoopInterface
      */
     public function addWriteStream($stream, callable $listener)
     {
+        if (isset($this->writeEvents[(int) $stream])) {
+            return;
+        }
+
         $callback = function () use ($stream, $listener) {
             call_user_func($listener, $stream, $this);
         };

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -47,11 +47,35 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->tick();
     }
 
+    public function testAddReadStreamIgnoresSecondCallable()
+    {
+        list ($input, $output) = $this->createSocketPair();
+
+        $this->loop->addReadStream($input, $this->expectCallableExactly(2));
+        $this->loop->addReadStream($input, $this->expectCallableNever());
+
+        fwrite($output, "foo\n");
+        $this->loop->tick();
+
+        fwrite($output, "bar\n");
+        $this->loop->tick();
+    }
+
     public function testAddWriteStream()
     {
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
+        $this->loop->tick();
+        $this->loop->tick();
+    }
+
+    public function testAddWriteStreamIgnoresSecondCallable()
+    {
+        list ($input) = $this->createSocketPair();
+
+        $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
+        $this->loop->addWriteStream($input, $this->expectCallableNever());
         $this->loop->tick();
         $this->loop->tick();
     }


### PR DESCRIPTION
This tests the current behavior. I think the behavior should be changed to throw an exception instead of silently ignoring those callables or just call both callables.