### PR TITLE
StreamSelectLoop: Int overflow for big timer intervals

### DIFF
--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -154,20 +154,9 @@ class StreamSelectLoop implements LoopInterface
             // Future-tick queue has pending callbacks ...
             if (!$this->running || !$this->futureTickQueue->isEmpty()) {
                 $timeout = 0;
-
             // There is a pending timer, only block until it is due ...
             } elseif ($scheduledAt = $this->timers->getFirst()) {
-                $timeout = $scheduledAt - $this->timers->getTime();
-                if ($timeout < 0) {
-                    $timeout = 0;
-                } else {
-                    /*
-                     * round() needed to correct float error:
-                     * https://github.com/reactphp/event-loop/issues/48
-                     */
-                    $timeout = round($timeout * self::MICROSECONDS_PER_SECOND);
-                }
-
+                $timeout = max($scheduledAt - $this->timers->getTime(), 0);
             // The only possible event is stream activity, so wait forever ...
             } elseif ($this->readStreams || $this->writeStreams) {
                 $timeout = null;
@@ -191,6 +180,8 @@ class StreamSelectLoop implements LoopInterface
 
     /**
      * Wait/check for stream activity, or until the next timer is due.
+     *
+     * @param float $timeout
      */
     private function waitForStreamActivity($timeout)
     {
@@ -282,22 +273,55 @@ class StreamSelectLoop implements LoopInterface
      *
      * @param array        &$read   An array of read streams to select upon.
      * @param array        &$write  An array of write streams to select upon.
-     * @param integer|null $timeout Activity timeout in microseconds, or null to wait forever.
+     * @param float|null   $timeout Activity timeout in seconds, or null to wait forever.
      *
      * @return integer|false The total number of streams that are ready for read/write.
      * Can return false if stream_select() is interrupted by a signal.
      */
     protected function streamSelect(array &$read, array &$write, $timeout)
     {
-        if ($read || $write) {
-            $except = null;
+        $seconds = self::getSeconds($timeout);
+        $microseconds = self::getMicroseconds($timeout);
+        $nanoseconds = self::getNanoseconds($timeout);
 
-            // suppress warnings that occur, when stream_select is interrupted by a signal
-            return @stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
+        if ($read || $write) {
+            $except = [];
+
+            return $this->doSelectStream($read, $write, $except, $seconds, $microseconds);
         }
 
-        $timeout && usleep($timeout);
+        $timeout && $this->sleep($seconds, $nanoseconds);
 
         return 0;
+    }
+
+    /**
+     * Proxy for built-in stream_select method.
+     *
+     * @param array $read
+     * @param array $write
+     * @param array $except
+     * @param int|null $seconds
+     * @param int|null $microseconds
+     *
+     * @return int
+     */
+    protected function doSelectStream(array &$read, array &$write, array &$except, $seconds, $microseconds = null)
+    {
+        // suppress warnings that occur, when stream_select is interrupted by a signal
+        return @stream_select($read, $write, $except, $seconds, $microseconds);
+    }
+
+    /**
+     * Sleeps for $seconds and $nanoseconds.
+     *
+     * @param int $seconds
+     * @param int $nanoseconds
+     */
+    protected function sleep($seconds, $nanoseconds = 0)
+    {
+        if ($seconds !== 0 && $nanoseconds !== 0) {
+            time_nanosleep($seconds, $nanoseconds);
+        }
     }
 }

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -156,15 +156,15 @@ class StreamSelectLoopTest extends AbstractLoopTest
     public function testSmallTimerInterval()
     {
         /** @var StreamSelectLoop|\PHPUnit_Framework_MockObject_MockObject $loop */
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['streamSelect']);
+        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['sleep']);
         $loop
             ->expects($this->at(0))
-            ->method('streamSelect')
-            ->with([], [], 1);
+            ->method('sleep')
+            ->with(0, intval(Timer::MIN_INTERVAL * StreamSelectLoop::NANOSECONDS_PER_SECOND));
         $loop
             ->expects($this->at(1))
-            ->method('streamSelect')
-            ->with([], [], 0);
+            ->method('sleep')
+            ->with(0, 0);
 
         $callsCount = 0;
         $loop->addPeriodicTimer(Timer::MIN_INTERVAL, function() use (&$loop, &$callsCount) {

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -176,4 +176,23 @@ class StreamSelectLoopTest extends AbstractLoopTest
 
         $loop->run();
     }
+
+    /**
+     * https://github.com/reactphp/event-loop/issues/19
+     *
+     * Tests that timer with PHP_INT_MAX seconds interval will work.
+     */
+    public function testIntOverflowTimerInterval()
+    {
+        /** @var StreamSelectLoop|\PHPUnit_Framework_MockObject_MockObject $loop */
+        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['sleep']);
+        $loop->expects($this->once())
+            ->method('sleep')
+            ->with(PHP_INT_MAX, 0)
+            ->willReturnCallback(function() use (&$loop) {
+                $loop->stop();
+            });
+        $loop->addTimer(PHP_INT_MAX, function(){});
+        $loop->run();
+    }
 }


### PR DESCRIPTION
### The problem

As described <a href="https://github.com/reactphp/event-loop/issues/19">here</a>, current `StreamSelectLoop` implementation restricts using time intervals more than `PHP_INT_MAX` microseconds. For 32-bit systems it's only 2148 seconds.

### Suggested solution

* Change `StreamSelectLoop` `$timeout` type from `int` (in microseconds) to `float` (in seconds);
* Replace `usleep` with `time_nanosleep`, cause `usleep` takes `int` argument in microseconds, and we can't keep more than `PHP_INT_MAX` microseconds. But `time_nanosleep` takes 2 arguments: `int` amount of seconds and `int` amount of nanoseconds, that allows `StreamSelectLoop` to handle `PHP_INT_MAX` seconds intervals;
* Extract `stream_select` and `time_nanosleep` methods calls from `StreamSelectLoop::streamSelect(...)` to test timeout values.
