### PR TITLE
StreamSelectLoop: Int overflow for big timer intervals

### DIFF
--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -281,16 +281,16 @@ class StreamSelectLoop implements LoopInterface
     protected function streamSelect(array &$read, array &$write, $timeout)
     {
         $seconds = $timeout === null ? null : self::getSeconds($timeout);
-        $microseconds = $timeout === null ? 0 : self::getMicroseconds($timeout);
-        $nanoseconds = $timeout === null ? 0 : self::getNanoseconds($timeout);
 
         if ($read || $write) {
             $except = [];
+            $microseconds = $timeout === null ? 0 : self::getMicroseconds($timeout);
 
             return $this->doSelectStream($read, $write, $except, $seconds, $microseconds);
         }
 
         if ($timeout !== null) {
+            $nanoseconds = self::getNanoseconds($timeout);
             $this->sleep($seconds, $nanoseconds);
         }
 

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -222,10 +222,15 @@ class StreamSelectLoop implements LoopInterface
     private static function getSeconds($time)
     {
         /*
-         * Workaround for PHP int overflow:
-         * (float)PHP_INT_MAX == PHP_INT_MAX => true
-         * (int)(float)PHP_INT_MAX == PHP_INT_MAX => false
-         * (int)(float)PHP_INT_MAX == PHP_INT_MIN => true
+         * intval(floor($time)) will produce int overflow
+         * if $time is (float)PHP_INT_MAX:
+         * (float)PHP_INT_MAX      == PHP_INT_MAX  //true
+         * (int)(float)PHP_INT_MAX == PHP_INT_MAX  //false
+         * (int)(float)PHP_INT_MAX == PHP_INT_MIN  //true
+         * -----------------------------------------------
+         * Loose comparision is intentional, cause $time
+         * is float and
+         * (float)PHP_INT_MAX !== PHP_INT_MAX
          */
         if ($time == PHP_INT_MAX) {
             return PHP_INT_MAX;

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -156,15 +156,15 @@ class StreamSelectLoopTest extends AbstractLoopTest
     public function testSmallTimerInterval()
     {
         /** @var StreamSelectLoop|\PHPUnit_Framework_MockObject_MockObject $loop */
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['streamSelect']);
+        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['sleep']);
         $loop
             ->expects($this->at(0))
-            ->method('streamSelect')
-            ->with([], [], 1);
+            ->method('sleep')
+            ->with(0, intval(Timer::MIN_INTERVAL * StreamSelectLoop::NANOSECONDS_PER_SECOND));
         $loop
             ->expects($this->at(1))
-            ->method('streamSelect')
-            ->with([], [], 0);
+            ->method('sleep')
+            ->with(0, 0);
 
         $callsCount = 0;
         $loop->addPeriodicTimer(Timer::MIN_INTERVAL, function() use (&$loop, &$callsCount) {

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -176,4 +176,23 @@ class StreamSelectLoopTest extends AbstractLoopTest
 
         $loop->run();
     }
+
+    /**
+     * https://github.com/reactphp/event-loop/issues/19
+     *
+     * Tests that timer with PHP_INT_MAX seconds interval will work.
+     */
+    public function testIntOverflowTimerInterval()
+    {
+        /** @var StreamSelectLoop|\PHPUnit_Framework_MockObject_MockObject $loop */
+        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['sleep']);
+        $loop->expects($this->once())
+            ->method('sleep')
+            ->with(PHP_INT_MAX, 0)
+            ->willReturnCallback(function() use (&$loop) {
+                $loop->stop();
+            });
+        $loop->addTimer(PHP_INT_MAX, function(){});
+        $loop->run();
+    }
 }


### PR DESCRIPTION
### The problem

As described <a href="https://github.com/reactphp/event-loop/issues/19">here</a>, current `StreamSelectLoop` implementation restricts using time intervals more than `PHP_INT_MAX` microseconds. For 32-bit systems it's only 2148 seconds.

### Suggested solution

* Change `StreamSelectLoop` `$timeout` type from `int` (in microseconds) to `float` (in seconds);
* Replace `usleep` with `time_nanosleep`, cause `usleep` takes `int` argument in microseconds, and we can't keep more than `PHP_INT_MAX` microseconds. But `time_nanosleep` takes 2 arguments: `int` amount of seconds and `int` amount of nanoseconds, that allows `StreamSelectLoop` to handle `PHP_INT_MAX` seconds intervals;
* Extract `stream_select` and `time_nanosleep` methods calls from `StreamSelectLoop::streamSelect(...)` to test timeout values.
