### PR TITLE
Tick callback receives no arguments, fix cyclic dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,33 @@ schedule a callback to be invoked on a future tick of the event loop.
 This works very much similar to timers with an interval of zero seconds,
 but does not require the overhead of scheduling a timer queue.
 
-Unlike timers, callbacks are guaranteed to be executed in the order they
-are enqueued.
+The tick callback function MUST be able to accept zero parameters.
+
+The tick callback function MUST NOT throw an `Exception`.
+The return value of the tick callback function will be ignored and has
+no effect, so for performance reasons you're recommended to not return
+any excessive data structures.
+
+If you want to access any variables within your callback function, you
+can bind arbitrary data to a callback closure like this:
+
+```php
+function hello(LoopInterface $loop, $name)
+{
+    $loop->futureTick(function () use ($name) {
+        echo "hello $name\n";
+    });
+}
+
+hello('Tester');
+```
+
+Unlike timers, tick callbacks are guaranteed to be executed in the order
+they are enqueued.
 Also, once a callback is enqueued, there's no way to cancel this operation.
 
-This is often used to break down bigger tasks into smaller steps (a form of
-cooperative multitasking).
+This is often used to break down bigger tasks into smaller steps (a form
+of cooperative multitasking).
 
 ```php
 $loop->futureTick(function () {

--- a/examples/91-benchmark-ticks.php
+++ b/examples/91-benchmark-ticks.php
@@ -9,7 +9,7 @@ $loop = Factory::create();
 $n = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 
 for ($i = 0; $i < $n; ++$i) {
-    $loop->nextTick(function () { });
+    $loop->futureTick(function () { });
 }
 
 $loop->run();

--- a/examples/93-benchmark-ticks-delay.php
+++ b/examples/93-benchmark-ticks-delay.php
@@ -11,7 +11,7 @@ $tick = function () use (&$tick, &$ticks, $loop) {
     if ($ticks > 0) {
         --$ticks;
         //$loop->addTimer(0, $tick);
-        $loop->nextTick($tick);
+        $loop->futureTick($tick);
     } else {
         echo 'done';
     }

--- a/examples/94-benchmark-timers-delay.php
+++ b/examples/94-benchmark-timers-delay.php
@@ -10,7 +10,7 @@ $ticks = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 $tick = function () use (&$tick, &$ticks, $loop) {
     if ($ticks > 0) {
         --$ticks;
-        //$loop->nextTick($tick);
+        //$loop->futureTick($tick);
         $loop->addTimer(0, $tick);
     } else {
         echo 'done';

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -29,7 +29,7 @@ class ExtEventLoop implements LoopInterface
     public function __construct(EventBaseConfig $config = null)
     {
         $this->eventBase = new EventBase($config);
-        $this->futureTickQueue = new FutureTickQueue($this);
+        $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
 
         $this->createTimerCallback();

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -26,7 +26,7 @@ class LibEvLoop implements LoopInterface
     public function __construct()
     {
         $this->loop = new EventLoop();
-        $this->futureTickQueue = new FutureTickQueue($this);
+        $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
     }
 

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -30,7 +30,7 @@ class LibEventLoop implements LoopInterface
     public function __construct()
     {
         $this->eventBase = event_base_new();
-        $this->futureTickQueue = new FutureTickQueue($this);
+        $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
 
         $this->createTimerCallback();

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -91,14 +91,49 @@ interface LoopInterface
      * This works very much similar to timers with an interval of zero seconds,
      * but does not require the overhead of scheduling a timer queue.
      *
-     * Unlike timers, callbacks are guaranteed to be executed in the order they
-     * are enqueued.
+     * The tick callback function MUST be able to accept zero parameters.
+     *
+     * The tick callback function MUST NOT throw an `Exception`.
+     * The return value of the tick callback function will be ignored and has
+     * no effect, so for performance reasons you're recommended to not return
+     * any excessive data structures.
+     *
+     * If you want to access any variables within your callback function, you
+     * can bind arbitrary data to a callback closure like this:
+     *
+     * ```php
+     * function hello(LoopInterface $loop, $name)
+     * {
+     *     $loop->futureTick(function () use ($name) {
+     *         echo "hello $name\n";
+     *     });
+     * }
+     *
+     * hello('Tester');
+     * ```
+     *
+     * Unlike timers, tick callbacks are guaranteed to be executed in the order
+     * they are enqueued.
      * Also, once a callback is enqueued, there's no way to cancel this operation.
      *
-     * This is often used to break down bigger tasks into smaller steps (a form of
-     * cooperative multitasking).
+     * This is often used to break down bigger tasks into smaller steps (a form
+     * of cooperative multitasking).
+     *
+     * ```php
+     * $loop->futureTick(function () {
+     *     echo 'b';
+     * });
+     * $loop->futureTick(function () {
+     *     echo 'c';
+     * });
+     * echo 'a';
+     * ```
+     *
+     * See also [example #3](examples).
      *
      * @param callable $listener The callback to invoke.
+     *
+     * @return void
      */
     public function futureTick(callable $listener);
 

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -24,7 +24,7 @@ class StreamSelectLoop implements LoopInterface
 
     public function __construct()
     {
-        $this->futureTickQueue = new FutureTickQueue($this);
+        $this->futureTickQueue = new FutureTickQueue();
         $this->timers = new Timers();
     }
 

--- a/src/Tick/FutureTickQueue.php
+++ b/src/Tick/FutureTickQueue.php
@@ -2,20 +2,14 @@
 
 namespace React\EventLoop\Tick;
 
-use React\EventLoop\LoopInterface;
 use SplQueue;
 
 class FutureTickQueue
 {
-    private $eventLoop;
     private $queue;
 
-    /**
-     * @param LoopInterface $eventLoop The event loop passed as the first parameter to callbacks.
-     */
-    public function __construct(LoopInterface $eventLoop)
+    public function __construct()
     {
-        $this->eventLoop = $eventLoop;
         $this->queue = new SplQueue();
     }
 
@@ -41,8 +35,7 @@ class FutureTickQueue
 
         while ($count--) {
             call_user_func(
-                $this->queue->dequeue(),
-                $this->eventLoop
+                $this->queue->dequeue()
             );
         }
     }

--- a/src/Tick/FutureTickQueue.php
+++ b/src/Tick/FutureTickQueue.php
@@ -4,7 +4,15 @@ namespace React\EventLoop\Tick;
 
 use SplQueue;
 
-class FutureTickQueue
+/**
+ * A tick queue implementation that can hold multiple callback functions
+ *
+ * This class should only be used internally, see LoopInterface instead.
+ *
+ * @see LoopInterface
+ * @internal
+ */
+final class FutureTickQueue
 {
     private $queue;
 

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -296,8 +296,7 @@ abstract class AbstractLoopTest extends TestCase
     {
         $called = false;
 
-        $callback = function ($loop) use (&$called) {
-            $this->assertSame($this->loop, $loop);
+        $callback = function () use (&$called) {
             $called = true;
         };
 


### PR DESCRIPTION
The tick API has been documented as part of #100, however it makes no mention of how the tick function should look like. It actually currently receives the loop instance, which is entirely undocumented. The loop parameter also causes an unneeded cyclic dependency which hinders garbage collection.

This simple PR changes it so that the tick callback no longer receives a loop argument. This is obviously a small BC break, so this PR ensures to provide some upgrade guides to those affected by this. This is now also in line with the timer API, see #102.

Builds on top of #100 and refs #102

## Remove loop argument and suggest using closure binding instead

```php
// old (loop passed as parameter)
$loop->futureTick(function ($loop) {
    $loop->stop();
});

// already supported before: use closure binding as usual
$loop->futureTick(function () use ($loop) {
    $loop->stop();
});
```