### PR TITLE
Lock Travis distro so new defaults will not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 7.0
   - 7.1
 
+# lock distro so new future defaults will not break the build
+dist: precise
+
 # also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,12 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: precise
+dist: trusty
 
-# also test against HHVM, but require "trusty" and ignore errors
 matrix:
-  include:
-    - php: hhvm
-      dist: trusty
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
Travis is in the process of upgrading the base distro (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) and despite all PRs currently being "green", may start to mark the current master as broken. Unlike https://github.com/reactphp/stream/pull/110 this project is not affected by Travis dropping support for older versions of PHP.

Builds on top of #105
Originally from clue/php-connection-manager-extra#24