### PR TITLE
Documentation for advanced stream API

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,15 +358,24 @@ the same time is not guaranteed.
 The `removeReadStream(resource $stream): void` method can be used to
 remove the read event listener for the given stream.
 
+Removing a stream from the loop that has already been removed or trying
+to remove a stream that was never added or is invalid has no effect.
+
 ### removeWriteStream()
 
 The `removeWriteStream(resource $stream): void` method can be used to
 remove the write event listener for the given stream.
 
+Removing a stream from the loop that has already been removed or trying
+to remove a stream that was never added or is invalid has no effect.
+
 ### removeStream()
 
 The `removeStream(resource $stream): void` method can be used to
 remove all listeners for the given stream.
+
+Removing a stream from the loop that has already been removed or trying
+to remove a stream that was never added or is invalid has no effect.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,13 @@ See also [example #3](examples).
 The `addReadStream(resource $stream, callable $callback): void` method can be used to
 register a listener to be notified when a stream is ready to read.
 
+The first parameter MUST be a valid stream resource that supports
+checking whether it is ready to read by this loop implementation.
+A single stream resource MUST NOT be added more than once.
+Instead, either call [`removeReadStream()`](#removereadstream) first or
+react to this event with a single listener and then dispatch from this
+listener.
+
 The listener callback function MUST be able to accept a single parameter,
 the stream resource added by this method or you MAY use a function which
 has no parameters at all.
@@ -326,6 +333,13 @@ the same time is not guaranteed.
 
 The `addWriteStream(resource $stream, callable $callback): void` method can be used to
 register a listener to be notified when a stream is ready to write.
+
+The first parameter MUST be a valid stream resource that supports
+checking whether it is ready to write by this loop implementation.
+A single stream resource MUST NOT be added more than once.
+Instead, either call [`removeWriteStream()`](#removewritestream) first or
+react to this event with a single listener and then dispatch from this
+listener.
 
 The listener callback function MUST be able to accept a single parameter,
 the stream resource added by this method or you MAY use a function which

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For the code of the current stable 0.4.x release, checkout the
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
+* [More](#more)
 
 ## Quickstart example
 
@@ -293,6 +294,11 @@ See also [example #3](examples).
 
 ### addReadStream()
 
+> Advanced! Note that this low-level API is considered advanced usage.
+  Most use cases should probably use the higher-level
+  [readable Stream API](https://github.com/reactphp/stream#readablestreaminterface)
+  instead.
+
 The `addReadStream(resource $stream, callable $callback): void` method can be used to
 register a listener to be notified when a stream is ready to read.
 
@@ -330,6 +336,11 @@ The execution order of listeners when multiple streams become ready at
 the same time is not guaranteed.
 
 ### addWriteStream()
+
+> Advanced! Note that this low-level API is considered advanced usage.
+  Most use cases should probably use the higher-level
+  [writable Stream API](https://github.com/reactphp/stream#writablestreaminterface)
+  instead.
 
 The `addWriteStream(resource $stream, callable $callback): void` method can be used to
 register a listener to be notified when a stream is ready to write.
@@ -420,3 +431,11 @@ $ php vendor/bin/phpunit
 ## License
 
 MIT, see [LICENSE file](LICENSE).
+
+## More
+
+* See our [Stream component](https://github.com/reactphp/stream) for more
+  information on how streams are used in real-world applications.
+* See our [users wiki](https://github.com/reactphp/react/wiki/Users) and the
+  [dependents on Packagist](https://packagist.org/packages/react/event-loop/dependents)
+  for a list of packages that use the EventLoop in real-world applications.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,83 @@ echo 'a';
 
 See also [example #3](examples).
 
+### addReadStream()
+
+The `addReadStream(resource $stream, callable $callback): void` method can be used to
+register a listener to be notified when a stream is ready to read.
+
+The listener callback function MUST be able to accept a single parameter,
+the stream resource added by this method or you MAY use a function which
+has no parameters at all.
+
+The listener callback function MUST NOT throw an `Exception`.
+The return value of the listener callback function will be ignored and has
+no effect, so for performance reasons you're recommended to not return
+any excessive data structures.
+
+If you want to access any variables within your callback function, you
+can bind arbitrary data to a callback closure like this:
+
+```php
+$loop->addReadStream($stream, function ($stream) use ($name) {
+    echo $name . ' said: ' . fread($stream);
+});
+```
+
+See also [example #11](examples).
+
+You can invoke [`removeReadStream()`](#removereadstream) to remove the
+read event listener for this stream.
+
+The execution order of listeners when multiple streams become ready at
+the same time is not guaranteed.
+
+### addWriteStream()
+
+The `addWriteStream(resource $stream, callable $callback): void` method can be used to
+register a listener to be notified when a stream is ready to write.
+
+The listener callback function MUST be able to accept a single parameter,
+the stream resource added by this method or you MAY use a function which
+has no parameters at all.
+
+The listener callback function MUST NOT throw an `Exception`.
+The return value of the listener callback function will be ignored and has
+no effect, so for performance reasons you're recommended to not return
+any excessive data structures.
+
+If you want to access any variables within your callback function, you
+can bind arbitrary data to a callback closure like this:
+
+```php
+$loop->addWriteStream($stream, function ($stream) use ($name) {
+    fwrite($stream, 'Hello ' . $name);
+});
+```
+
+See also [example #12](examples).
+
+You can invoke [`removeWriteStream()`](#removewritestream) to remove the
+write event listener for this stream.
+
+The execution order of listeners when multiple streams become ready at
+the same time is not guaranteed.
+
+### removeReadStream()
+
+The `removeReadStream(resource $stream): void` method can be used to
+remove the read event listener for the given stream.
+
+### removeWriteStream()
+
+The `removeWriteStream(resource $stream): void` method can be used to
+remove the write event listener for the given stream.
+
+### removeStream()
+
+The `removeStream(resource $stream): void` method can be used to
+remove all listeners for the given stream.
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -289,11 +289,11 @@ class ExtEventLoop implements LoopInterface
             $key = (int) $stream;
 
             if (Event::READ === (Event::READ & $flags) && isset($this->readListeners[$key])) {
-                call_user_func($this->readListeners[$key], $stream, $this);
+                call_user_func($this->readListeners[$key], $stream);
             }
 
             if (Event::WRITE === (Event::WRITE & $flags) && isset($this->writeListeners[$key])) {
-                call_user_func($this->writeListeners[$key], $stream, $this);
+                call_user_func($this->writeListeners[$key], $stream);
             }
         };
     }

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -40,7 +40,7 @@ class LibEvLoop implements LoopInterface
         }
 
         $callback = function () use ($stream, $listener) {
-            call_user_func($listener, $stream, $this);
+            call_user_func($listener, $stream);
         };
 
         $event = new IOEvent($callback, $stream, IOEvent::READ);
@@ -59,7 +59,7 @@ class LibEvLoop implements LoopInterface
         }
 
         $callback = function () use ($stream, $listener) {
-            call_user_func($listener, $stream, $this);
+            call_user_func($listener, $stream);
         };
 
         $event = new IOEvent($callback, $stream, IOEvent::WRITE);

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -307,11 +307,11 @@ class LibEventLoop implements LoopInterface
             $key = (int) $stream;
 
             if (EV_READ === (EV_READ & $flags) && isset($this->readListeners[$key])) {
-                call_user_func($this->readListeners[$key], $stream, $this);
+                call_user_func($this->readListeners[$key], $stream);
             }
 
             if (EV_WRITE === (EV_WRITE & $flags) && isset($this->writeListeners[$key])) {
-                call_user_func($this->writeListeners[$key], $stream, $this);
+                call_user_func($this->writeListeners[$key], $stream);
             }
         };
     }

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -9,6 +9,13 @@ interface LoopInterface
     /**
      * Register a listener to be notified when a stream is ready to read.
      *
+     * The first parameter MUST be a valid stream resource that supports
+     * checking whether it is ready to read by this loop implementation.
+     * A single stream resource MUST NOT be added more than once.
+     * Instead, either call [`removeReadStream()`](#removereadstream) first or
+     * react to this event with a single listener and then dispatch from this
+     * listener.
+     *
      * The listener callback function MUST be able to accept a single parameter,
      * the stream resource added by this method or you MAY use a function which
      * has no parameters at all.
@@ -37,11 +44,19 @@ interface LoopInterface
      *
      * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
+     * @see self::removeReadStream()
      */
     public function addReadStream($stream, callable $listener);
 
     /**
      * Register a listener to be notified when a stream is ready to write.
+     *
+     * The first parameter MUST be a valid stream resource that supports
+     * checking whether it is ready to write by this loop implementation.
+     * A single stream resource MUST NOT be added more than once.
+     * Instead, either call [`removeWriteStream()`](#removewritestream) first or
+     * react to this event with a single listener and then dispatch from this
+     * listener.
      *
      * The listener callback function MUST be able to accept a single parameter,
      * the stream resource added by this method or you MAY use a function which
@@ -71,6 +86,7 @@ interface LoopInterface
      *
      * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
+     * @see self::removeWriteStream()
      */
     public function addWriteStream($stream, callable $listener);
 

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -9,6 +9,32 @@ interface LoopInterface
     /**
      * Register a listener to be notified when a stream is ready to read.
      *
+     * The listener callback function MUST be able to accept a single parameter,
+     * the stream resource added by this method or you MAY use a function which
+     * has no parameters at all.
+     *
+     * The listener callback function MUST NOT throw an `Exception`.
+     * The return value of the listener callback function will be ignored and has
+     * no effect, so for performance reasons you're recommended to not return
+     * any excessive data structures.
+     *
+     * If you want to access any variables within your callback function, you
+     * can bind arbitrary data to a callback closure like this:
+     *
+     * ```php
+     * $loop->addReadStream($stream, function ($stream) use ($name) {
+     *     echo $name . ' said: ' . fread($stream);
+     * });
+     * ```
+     *
+     * See also [example #11](examples).
+     *
+     * You can invoke [`removeReadStream()`](#removereadstream) to remove the
+     * read event listener for this stream.
+     *
+     * The execution order of listeners when multiple streams become ready at
+     * the same time is not guaranteed.
+     *
      * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.
      */
@@ -16,6 +42,32 @@ interface LoopInterface
 
     /**
      * Register a listener to be notified when a stream is ready to write.
+     *
+     * The listener callback function MUST be able to accept a single parameter,
+     * the stream resource added by this method or you MAY use a function which
+     * has no parameters at all.
+     *
+     * The listener callback function MUST NOT throw an `Exception`.
+     * The return value of the listener callback function will be ignored and has
+     * no effect, so for performance reasons you're recommended to not return
+     * any excessive data structures.
+     *
+     * If you want to access any variables within your callback function, you
+     * can bind arbitrary data to a callback closure like this:
+     *
+     * ```php
+     * $loop->addWriteStream($stream, function ($stream) use ($name) {
+     *     fwrite($stream, 'Hello ' . $name);
+     * });
+     * ```
+     *
+     * See also [example #12](examples).
+     *
+     * You can invoke [`removeWriteStream()`](#removewritestream) to remove the
+     * write event listener for this stream.
+     *
+     * The execution order of listeners when multiple streams become ready at
+     * the same time is not guaranteed.
      *
      * @param resource $stream   The PHP stream resource to check.
      * @param callable $listener Invoked when the stream is ready.

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -77,6 +77,9 @@ interface LoopInterface
     /**
      * Remove the read event listener for the given stream.
      *
+     * Removing a stream from the loop that has already been removed or trying
+     * to remove a stream that was never added or is invalid has no effect.
+     *
      * @param resource $stream The PHP stream resource.
      */
     public function removeReadStream($stream);
@@ -84,12 +87,18 @@ interface LoopInterface
     /**
      * Remove the write event listener for the given stream.
      *
+     * Removing a stream from the loop that has already been removed or trying
+     * to remove a stream that was never added or is invalid has no effect.
+     *
      * @param resource $stream The PHP stream resource.
      */
     public function removeWriteStream($stream);
 
     /**
      * Remove all listeners for the given stream.
+     *
+     * Removing a stream from the loop that has already been removed or trying
+     * to remove a stream that was never added or is invalid has no effect.
      *
      * @param resource $stream The PHP stream resource.
      */

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -7,7 +7,12 @@ use React\EventLoop\Timer\TimerInterface;
 interface LoopInterface
 {
     /**
-     * Register a listener to be notified when a stream is ready to read.
+     * [Advanced] Register a listener to be notified when a stream is ready to read.
+     *
+     * Note that this low-level API is considered advanced usage.
+     * Most use cases should probably use the higher-level
+     * [readable Stream API](https://github.com/reactphp/stream#readablestreaminterface)
+     * instead.
      *
      * The first parameter MUST be a valid stream resource that supports
      * checking whether it is ready to read by this loop implementation.
@@ -49,7 +54,12 @@ interface LoopInterface
     public function addReadStream($stream, callable $listener);
 
     /**
-     * Register a listener to be notified when a stream is ready to write.
+     * [Advanced] Register a listener to be notified when a stream is ready to write.
+     *
+     * Note that this low-level API is considered advanced usage.
+     * Most use cases should probably use the higher-level
+     * [writable Stream API](https://github.com/reactphp/stream#writablestreaminterface)
+     * instead.
      *
      * The first parameter MUST be a valid stream resource that supports
      * checking whether it is ready to write by this loop implementation.

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -206,7 +206,7 @@ class StreamSelectLoop implements LoopInterface
             $key = (int) $stream;
 
             if (isset($this->readListeners[$key])) {
-                call_user_func($this->readListeners[$key], $stream, $this);
+                call_user_func($this->readListeners[$key], $stream);
             }
         }
 
@@ -214,7 +214,7 @@ class StreamSelectLoop implements LoopInterface
             $key = (int) $stream;
 
             if (isset($this->writeListeners[$key])) {
-                call_user_func($this->writeListeners[$key], $stream, $this);
+                call_user_func($this->writeListeners[$key], $stream);
             }
         }
     }

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -90,11 +90,11 @@ class StreamSelectLoopTest extends AbstractLoopTest
 
         // add stream to the loop
         list($writeStream, $readStream) = $this->createSocketPair();
-        $this->loop->addReadStream($readStream, function($stream, $loop) {
+        $this->loop->addReadStream($readStream, function ($stream) {
             /** @var $loop LoopInterface */
             $read = fgets($stream);
             if ($read === "end loop\n") {
-                $loop->stop();
+                $this->loop->stop();
             }
         });
         $this->loop->addTimer(0.05, function() use ($writeStream) {


### PR DESCRIPTION
The stream API is currently mostly undocumented. This PR adds documentation for the existing stream API and then subsequently removes the unneeded and undocumented loop argument that was previously passed to stream listeners.

This is a subtle BC break. Empirical evidence (including our examples, tests and other components) suggest that most consumers will not be affected by this. The added documentation ensures that we now follow a strict API and will not introduce a BC break in the future.

Trying to create documentation for this API is not exactly trivial, as it's very low-level and has existed in this form almost since its inception. Given that most consumers SHOULD NOT use this API at all, I've marked the stream API as advanced and linked to the Stream component instead.

Performance improvement is not a major motivation here, but shows a negligible improvement anyway (running examples 92 and 94).

If you want to review, consider also looking at the individual commits.

Builds on top of #100 and #102.
Resolves / closes #87