### PR TITLE
[RFC] Remove removeStream() method, use removeReadStream/removeWriteStream instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $loop->addReadStream($server, function ($server) use ($loop) {
         $written = fwrite($conn, $data);
         if ($written === strlen($data)) {
             fclose($conn);
-            $loop->removeStream($conn);
+            $loop->removeWriteStream($conn);
         } else {
             $data = substr($data, $written);
         }
@@ -390,14 +390,6 @@ to remove a stream that was never added or is invalid has no effect.
 
 The `removeWriteStream(resource $stream): void` method can be used to
 remove the write event listener for the given stream.
-
-Removing a stream from the loop that has already been removed or trying
-to remove a stream that was never added or is invalid has no effect.
-
-### removeStream()
-
-The `removeStream(resource $stream): void` method can be used to
-remove all listeners for the given stream.
 
 Removing a stream from the loop that has already been removed or trying
 to remove a stream that was never added or is invalid has no effect.

--- a/examples/21-http-server.php
+++ b/examples/21-http-server.php
@@ -14,7 +14,7 @@ $loop->addReadStream($server, function ($server) use ($loop) {
         $written = fwrite($conn, $data);
         if ($written === strlen($data)) {
             fclose($conn);
-            $loop->removeStream($conn);
+            $loop->removeWriteStream($conn);
         } else {
             $data = substr($data, $written);
         }

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -88,10 +88,7 @@ class ExtEventLoop implements LoopInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeStream($stream)
+    private function removeStream($stream)
     {
         $key = (int) $stream;
 

--- a/src/LibEvLoop.php
+++ b/src/LibEvLoop.php
@@ -97,15 +97,6 @@ class LibEvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeStream($stream)
-    {
-        $this->removeReadStream($stream);
-        $this->removeWriteStream($stream);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addTimer($interval, callable $callback)
     {
         $timer = new Timer( $interval, $callback, false);

--- a/src/LibEventLoop.php
+++ b/src/LibEventLoop.php
@@ -89,10 +89,7 @@ class LibEventLoop implements LoopInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeStream($stream)
+    private function removeStream($stream)
     {
         $key = (int) $stream;
 

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -121,16 +121,6 @@ interface LoopInterface
     public function removeWriteStream($stream);
 
     /**
-     * Remove all listeners for the given stream.
-     *
-     * Removing a stream from the loop that has already been removed or trying
-     * to remove a stream that was never added or is invalid has no effect.
-     *
-     * @param resource $stream The PHP stream resource.
-     */
-    public function removeStream($stream);
-
-    /**
      * Enqueue a callback to be invoked once after the given interval.
      *
      * The timer callback function MUST be able to accept a single parameter,

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -83,15 +83,6 @@ class StreamSelectLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeStream($stream)
-    {
-        $this->removeReadStream($stream);
-        $this->removeWriteStream($stream);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addTimer($interval, callable $callback)
     {
         $timer = new Timer($interval, $callback, false);

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -126,18 +126,6 @@ abstract class AbstractLoopTest extends TestCase
         $this->tickLoop($this->loop);
     }
 
-    public function testRemoveStreamInstantly()
-    {
-        list ($input, $output) = $this->createSocketPair();
-
-        $this->loop->addReadStream($input, $this->expectCallableNever());
-        $this->loop->addWriteStream($input, $this->expectCallableNever());
-        $this->loop->removeStream($input);
-
-        fwrite($output, "bar\n");
-        $this->tickLoop($this->loop);
-    }
-
     public function testRemoveStreamForReadOnly()
     {
         list ($input, $output) = $this->createSocketPair();
@@ -163,22 +151,6 @@ abstract class AbstractLoopTest extends TestCase
         $this->tickLoop($this->loop);
     }
 
-    public function testRemoveStream()
-    {
-        list ($input, $output) = $this->createSocketPair();
-
-        $this->loop->addReadStream($input, $this->expectCallableOnce());
-        $this->loop->addWriteStream($input, $this->expectCallableOnce());
-
-        fwrite($output, "bar\n");
-        $this->tickLoop($this->loop);
-
-        $this->loop->removeStream($input);
-
-        fwrite($output, "bar\n");
-        $this->tickLoop($this->loop);
-    }
-
     public function testRemoveInvalid()
     {
         list ($stream) = $this->createSocketPair();
@@ -186,7 +158,6 @@ abstract class AbstractLoopTest extends TestCase
         // remove a valid stream from the event loop that was never added in the first place
         $this->loop->removeReadStream($stream);
         $this->loop->removeWriteStream($stream);
-        $this->loop->removeStream($stream);
     }
 
     /** @test */
@@ -202,7 +173,7 @@ abstract class AbstractLoopTest extends TestCase
 
         $loop = $this->loop;
         $this->loop->addReadStream($input, function ($stream) use ($loop) {
-            $loop->removeStream($stream);
+            $loop->removeReadStream($stream);
         });
 
         fwrite($output, "foo\n");
@@ -366,7 +337,7 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->addWriteStream(
             $stream,
             function () use ($stream) {
-                $this->loop->removeStream($stream);
+                $this->loop->removeWriteStream($stream);
                 $this->loop->futureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;


### PR DESCRIPTION
The `removeStream()` acts as a shortcut to essentially call both `removeReadStream()` and `removeWriteStream()` in one go. It's unclear how much value this method actually provides and it looks like this has attracted some low quality code in the past. As such, I'm filing this PR as an RFC to see if it makes sense to drop this unneeded method.

Refs #110