### PR TITLE
Forward compatibility with PHPUnit 6 and PHPUnit 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35"
+        "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"
     },
     "suggest": {
         "ext-libevent": ">=0.1.0 for LibEventLoop and PHP5 only",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8.35"
     },
     "suggest": {
         "ext-libevent": ">=0.1.0 for LibEventLoop and PHP5 only",

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -154,7 +154,9 @@ class StreamSelectLoopTest extends AbstractLoopTest
     public function testSmallTimerInterval()
     {
         /** @var StreamSelectLoop|\PHPUnit_Framework_MockObject_MockObject $loop */
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', ['streamSelect']);
+        $loop = $this->getMockBuilder('React\EventLoop\StreamSelectLoop')
+                    ->setMethods(['streamSelect'])
+                    ->getMock();
         $loop
             ->expects($this->at(0))
             ->method('streamSelect')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,10 @@
 
 namespace React\Tests\EventLoop;
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use React\EventLoop\LoopInterface;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     protected function expectCallableExactly($amount)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.