### PR TITLE
Fix ExtEventLoop to keep track of stream resources (refcount)

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -22,6 +22,7 @@ class ExtEventLoop implements LoopInterface
     private $streamCallback;
     private $streamEvents = [];
     private $streamFlags = [];
+    private $streamRefs = [];
     private $readListeners = [];
     private $writeListeners = [];
     private $running;
@@ -110,7 +111,8 @@ class ExtEventLoop implements LoopInterface
                 $this->streamFlags[$key],
                 $this->streamEvents[$key],
                 $this->readListeners[$key],
-                $this->writeListeners[$key]
+                $this->writeListeners[$key],
+                $this->streamRefs[$key]
             );
         }
     }
@@ -224,6 +226,12 @@ class ExtEventLoop implements LoopInterface
 
             $this->streamEvents[$key] = $event;
             $this->streamFlags[$key] = $flag;
+
+            // ext-event does not increase refcount on stream resources for PHP 7+
+            // manually keep track of stream resource to prevent premature garbage collection
+            if (PHP_VERSION_ID >= 70000) {
+                $this->streamRefs[$key] = $stream;
+            }
         }
 
         $event->add();


### PR DESCRIPTION
It has come to our attention that certain loop implementations do not keep track of assigned stream resources (refcount). This means that stream resources may be garbage collected despite being added to the loop when leaving the scope where they have been defined. Arguably, this is a design decision that makes sense for a number of PHP extension modules.

This issue is implicitly avoiding by using react/stream, which stores the stream resource in a member variable and thus prevents garbage collection. This means that this is not an issue for most people that rely on this component. However, this issue can be exhibited quite easily by using the EventLoop directly.

Given that our loop interface tries to abstract these underlying differences, we may have to keep track of stream resources within our loop abstractions.

~~~I'm marking this as WIP until we can pinpoint, reproduce and fix the underlying issue or work out another reasonable work around.~~~