### PR TITLE
Consistent naming for event loop implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ For the code of the current stable 0.4.x release, checkout the
     * [create()](#create)
   * [Loop implementations](#loop-implementations)
     * [StreamSelectLoop](#streamselectloop)
-    * [LibEventLoop](#libeventloop)
-    * [LibEvLoop](#libevloop)
     * [ExtEventLoop](#exteventloop)
+    * [ExtLibeventLoop](#extlibeventloop)
+    * [ExtLibevLoop](#extlibevloop)
   * [LoopInterface](#loopinterface)
     * [addtimer()](#addtimer)
     * [addPeriodicTimer()](#addperiodictimer)
@@ -184,7 +184,16 @@ It is commonly installed as part of many PHP distributions.
 If this extension is missing (or you're running on Windows), signal handling is
 not supported and throws a `BadMethodCallException` instead.
 
-#### LibEventLoop
+#### ExtEventLoop
+
+An `ext-event` based event loop.
+
+This uses the [`event` PECL extension](https://pecl.php.net/package/event).
+It supports the same backends as libevent.
+
+This loop is known to work with PHP 5.4 through PHP 7+.
+
+#### ExtLibeventLoop
 
 An `ext-libevent` based event loop.
 
@@ -198,7 +207,7 @@ To reiterate: Using this event loop on PHP 7 is not recommended.
 Accordingly, the [`Factory`](#factory) will not try to use this event loop on
 PHP 7.
 
-#### LibEvLoop
+#### ExtLibevLoop
 
 An `ext-libev` based event loop.
 
@@ -208,15 +217,6 @@ It supports the same backends as libevent.
 This loop does only work with PHP 5.
 An update for PHP 7 is [unlikely](https://github.com/m4rw3r/php-libev/issues/8)
 to happen any time soon.
-
-#### ExtEventLoop
-
-An `ext-event` based event loop.
-
-This uses the [`event` PECL extension](https://pecl.php.net/package/event).
-It supports the same backends as libevent.
-
-This loop is known to work with PHP 5.4 through PHP 7+.
 
 ### LoopInterface
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"
     },
     "suggest": {
-        "ext-libevent": ">=0.1.0 for LibEventLoop and PHP5 only",
         "ext-event": "~1.0 for ExtEventLoop",
-        "ext-libev": "for LibEvLoop",
-        "ext-pcntl": "For signals support when using the stream_select loop"
+        "ext-libevent": ">=0.1.0 for ExtLibeventLoop and PHP 5 only",
+        "ext-libev": "for ExtLibevLoop and PHP 5 only",
+        "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
     },
     "autoload": {
         "psr-4": {

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -24,7 +24,7 @@ use SplObjectStorage;
  * @see https://github.com/m4rw3r/php-libev
  * @see https://gist.github.com/1688204
  */
-class LibEvLoop implements LoopInterface
+class ExtLibevLoop implements LoopInterface
 {
     private $loop;
     private $futureTickQueue;

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -24,7 +24,7 @@ use SplObjectStorage;
  *
  * @link https://pecl.php.net/package/libevent
  */
-class LibEventLoop implements LoopInterface
+class ExtLibeventLoop implements LoopInterface
 {
     const MICROSECONDS_PER_SECOND = 1000000;
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,12 +25,12 @@ class Factory
     {
         // @codeCoverageIgnoreStart
         if (class_exists('libev\EventLoop', false)) {
-            return new LibEvLoop;
+            return new ExtLibevLoop();
         } elseif (class_exists('EventBase', false)) {
-            return new ExtEventLoop;
+            return new ExtEventLoop();
         } elseif (function_exists('event_base_new') && PHP_VERSION_ID < 70000) {
             // only use ext-libevent on PHP < 7 for now
-            return new LibEventLoop();
+            return new ExtLibeventLoop();
         }
 
         return new StreamSelectLoop();

--- a/tests/ExtLibevLoopTest.php
+++ b/tests/ExtLibevLoopTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\EventLoop;
 
-use React\EventLoop\LibEvLoop;
+use React\EventLoop\ExtLibevLoop;
 
-class LibEvLoopTest extends AbstractLoopTest
+class ExtLibevLoopTest extends AbstractLoopTest
 {
     public function createLoop()
     {
@@ -12,11 +12,11 @@ class LibEvLoopTest extends AbstractLoopTest
             $this->markTestSkipped('libev tests skipped because ext-libev is not installed.');
         }
 
-        return new LibEvLoop();
+        return new ExtLibevLoop();
     }
 
     public function testLibEvConstructor()
     {
-        $loop = new LibEvLoop();
+        $loop = new ExtLibevLoop();
     }
 }

--- a/tests/ExtLibeventLoopTest.php
+++ b/tests/ExtLibeventLoopTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\EventLoop;
 
-use React\EventLoop\LibEventLoop;
+use React\EventLoop\ExtLibeventLoop;
 
-class LibEventLoopTest extends AbstractLoopTest
+class ExtLibeventLoopTest extends AbstractLoopTest
 {
     private $fifoPath;
 
@@ -18,7 +18,7 @@ class LibEventLoopTest extends AbstractLoopTest
             $this->markTestSkipped('libevent tests skipped because ext-libevent is not installed.');
         }
 
-        return new LibEventLoop();
+        return new ExtLibeventLoop();
     }
 
     public function tearDown()

--- a/tests/Timer/ExtLibevTimerTest.php
+++ b/tests/Timer/ExtLibevTimerTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\EventLoop\Timer;
 
-use React\EventLoop\LibEvLoop;
+use React\EventLoop\ExtLibevLoop;
 
-class LibEvTimerTest extends AbstractTimerTest
+class ExtLibevTimerTest extends AbstractTimerTest
 {
     public function createLoop()
     {
@@ -12,6 +12,6 @@ class LibEvTimerTest extends AbstractTimerTest
             $this->markTestSkipped('libev tests skipped because ext-libev is not installed.');
         }
 
-        return new LibEvLoop();
+        return new ExtLibevLoop();
     }
 }

--- a/tests/Timer/ExtLibeventTimerTest.php
+++ b/tests/Timer/ExtLibeventTimerTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\EventLoop\Timer;
 
-use React\EventLoop\LibEventLoop;
+use React\EventLoop\ExtLibeventLoop;
 
-class LibEventTimerTest extends AbstractTimerTest
+class ExtLibeventTimerTest extends AbstractTimerTest
 {
     public function createLoop()
     {
@@ -12,6 +12,6 @@ class LibEventTimerTest extends AbstractTimerTest
             $this->markTestSkipped('libevent tests skipped because ext-libevent is not installed.');
         }
 
-        return new LibEventLoop();
+        return new ExtLibeventLoop();
     }
 }


### PR DESCRIPTION
This simple PR ensure we use a consistent naming scheme for all event loop implementations.

* rename `LibEventLoop` to `ExtLibeventLoop` (`ext-libevent`) and
* rename`LibEvLoop` to `ExtLibevLoop` (`ext-libev`),
* keep `ExtEventLoop` (`ext-event`),
* keep `StreamSelectLoop` (does not require an extension).

Resolves / closes #115
Builds on top of #127