### PR TITLE
Mark all classes as final to discourage inheritance

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -20,7 +20,7 @@ use SplObjectStorage;
  *
  * @link https://pecl.php.net/package/event
  */
-class ExtEventLoop implements LoopInterface
+final class ExtEventLoop implements LoopInterface
 {
     private $eventBase;
     private $futureTickQueue;

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -24,7 +24,7 @@ use SplObjectStorage;
  * @see https://github.com/m4rw3r/php-libev
  * @see https://gist.github.com/1688204
  */
-class ExtLibevLoop implements LoopInterface
+final class ExtLibevLoop implements LoopInterface
 {
     private $loop;
     private $futureTickQueue;

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -35,6 +35,7 @@ use SplObjectStorage;
  */
 class ExtLibeventLoop implements LoopInterface
 {
+    /** @internal */
     const MICROSECONDS_PER_SECOND = 1000000;
 
     private $eventBase;

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -33,7 +33,7 @@ use SplObjectStorage;
  *
  * @link https://pecl.php.net/package/libevent
  */
-class ExtLibeventLoop implements LoopInterface
+final class ExtLibeventLoop implements LoopInterface
 {
     /** @internal */
     const MICROSECONDS_PER_SECOND = 1000000;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -5,7 +5,7 @@ namespace React\EventLoop;
 /**
  * The `Factory` class exists as a convenient way to pick the best available event loop implementation.
  */
-class Factory
+final class Factory
 {
     /**
      * Creates a new event loop instance

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -52,6 +52,7 @@ use React\EventLoop\Timer\Timers;
  */
 class StreamSelectLoop implements LoopInterface
 {
+    /** @internal */
     const MICROSECONDS_PER_SECOND = 1000000;
 
     private $futureTickQueue;
@@ -268,7 +269,7 @@ class StreamSelectLoop implements LoopInterface
      * @return integer|false The total number of streams that are ready for read/write.
      * Can return false if stream_select() is interrupted by a signal.
      */
-    protected function streamSelect(array &$read, array &$write, $timeout)
+    private function streamSelect(array &$read, array &$write, $timeout)
     {
         if ($read || $write) {
             $except = null;

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -50,7 +50,7 @@ use React\EventLoop\Timer\Timers;
  *
  * @link http://php.net/manual/en/function.stream-select.php
  */
-class StreamSelectLoop implements LoopInterface
+final class StreamSelectLoop implements LoopInterface
 {
     /** @internal */
     const MICROSECONDS_PER_SECOND = 1000000;


### PR DESCRIPTION
Classes should be used via composition rather than extension.
This reduces our API footprint and avoids future BC breaks by avoiding
exposing its internal assumptions.

Builds on top of #128