### PR TITLE
[RFC] Remove all callable type hints for consistency and performance reasons

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -67,7 +67,7 @@ final class ExtEventLoop implements LoopInterface
         $this->createStreamCallback();
     }
 
-    public function addReadStream($stream, callable $listener)
+    public function addReadStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -77,7 +77,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function addWriteStream($stream, callable $listener)
+    public function addWriteStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -124,7 +124,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function addTimer($interval, callable $callback)
+    public function addTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -133,7 +133,7 @@ final class ExtEventLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, callable $callback)
+    public function addPeriodicTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -150,17 +150,17 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function futureTick(callable $listener)
+    public function futureTick($listener)
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, callable $listener)
+    public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
     }
 
-    public function removeSignal($signal, callable $listener)
+    public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
     }

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -63,7 +63,7 @@ final class ExtLibevLoop implements LoopInterface
         );
     }
 
-    public function addReadStream($stream, callable $listener)
+    public function addReadStream($stream, $listener)
     {
         if (isset($this->readEvents[(int) $stream])) {
             return;
@@ -79,7 +79,7 @@ final class ExtLibevLoop implements LoopInterface
         $this->readEvents[(int) $stream] = $event;
     }
 
-    public function addWriteStream($stream, callable $listener)
+    public function addWriteStream($stream, $listener)
     {
         if (isset($this->writeEvents[(int) $stream])) {
             return;
@@ -115,7 +115,7 @@ final class ExtLibevLoop implements LoopInterface
         }
     }
 
-    public function addTimer($interval, callable $callback)
+    public function addTimer($interval, $callback)
     {
         $timer = new Timer( $interval, $callback, false);
 
@@ -134,7 +134,7 @@ final class ExtLibevLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, callable $callback)
+    public function addPeriodicTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -157,17 +157,17 @@ final class ExtLibevLoop implements LoopInterface
         }
     }
 
-    public function futureTick(callable $listener)
+    public function futureTick($listener)
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, callable $listener)
+    public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
     }
 
-    public function removeSignal($signal, callable $listener)
+    public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
     }

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -85,7 +85,7 @@ final class ExtLibeventLoop implements LoopInterface
         $this->createStreamCallback();
     }
 
-    public function addReadStream($stream, callable $listener)
+    public function addReadStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -95,7 +95,7 @@ final class ExtLibeventLoop implements LoopInterface
         }
     }
 
-    public function addWriteStream($stream, callable $listener)
+    public function addWriteStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -144,7 +144,7 @@ final class ExtLibeventLoop implements LoopInterface
         }
     }
 
-    public function addTimer($interval, callable $callback)
+    public function addTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -153,7 +153,7 @@ final class ExtLibeventLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, callable $callback)
+    public function addPeriodicTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -174,17 +174,17 @@ final class ExtLibeventLoop implements LoopInterface
         }
     }
 
-    public function futureTick(callable $listener)
+    public function futureTick($listener)
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, callable $listener)
+    public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
     }
 
-    public function removeSignal($signal, callable $listener)
+    public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
     }

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -51,7 +51,7 @@ interface LoopInterface
      * @param callable $listener Invoked when the stream is ready.
      * @see self::removeReadStream()
      */
-    public function addReadStream($stream, callable $listener);
+    public function addReadStream($stream, $listener);
 
     /**
      * [Advanced] Register a listener to be notified when a stream is ready to write.
@@ -106,7 +106,7 @@ interface LoopInterface
      * @param callable $listener Invoked when the stream is ready.
      * @see self::removeWriteStream()
      */
-    public function addWriteStream($stream, callable $listener);
+    public function addWriteStream($stream, $listener);
 
     /**
      * Remove the read event listener for the given stream.
@@ -178,7 +178,7 @@ interface LoopInterface
      *
      * @return TimerInterface
      */
-    public function addTimer($interval, callable $callback);
+    public function addTimer($interval, $callback);
 
     /**
      * Enqueue a callback to be invoked repeatedly after the given interval.
@@ -248,7 +248,7 @@ interface LoopInterface
      *
      * @return TimerInterface
      */
-    public function addPeriodicTimer($interval, callable $callback);
+    public function addPeriodicTimer($interval, $callback);
 
     /**
      * Cancel a pending timer.
@@ -314,7 +314,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function futureTick(callable $listener);
+    public function futureTick($listener);
 
     /**
      * Register a listener to be notified when a signal has been caught by this process.
@@ -356,7 +356,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function addSignal($signal, callable $listener);
+    public function addSignal($signal, $listener);
 
     /**
      * Removes a previously added signal listener.
@@ -372,7 +372,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function removeSignal($signal, callable $listener);
+    public function removeSignal($signal, $listener);
 
     /**
      * Run the event loop until there are no more tasks to perform.

--- a/src/SignalsHandler.php
+++ b/src/SignalsHandler.php
@@ -15,7 +15,7 @@ final class SignalsHandler
     private $on;
     private $off;
 
-    public function __construct(LoopInterface $loop, callable $on, callable $off)
+    public function __construct(LoopInterface $loop, $on, $off)
     {
         $this->loop = $loop;
         $this->on = $on;
@@ -30,7 +30,7 @@ final class SignalsHandler
         }
     }
 
-    public function add($signal, callable $listener)
+    public function add($signal, $listener)
     {
         if (count($this->signals) == 0 && $this->timer === null) {
             /**
@@ -53,7 +53,7 @@ final class SignalsHandler
         $this->signals[$signal][] = $listener;
     }
 
-    public function remove($signal, callable $listener)
+    public function remove($signal, $listener)
     {
         if (!isset($this->signals[$signal])) {
             return;

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -90,7 +90,7 @@ final class StreamSelectLoop implements LoopInterface
         );
     }
 
-    public function addReadStream($stream, callable $listener)
+    public function addReadStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -100,7 +100,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function addWriteStream($stream, callable $listener)
+    public function addWriteStream($stream, $listener)
     {
         $key = (int) $stream;
 
@@ -130,7 +130,7 @@ final class StreamSelectLoop implements LoopInterface
         );
     }
 
-    public function addTimer($interval, callable $callback)
+    public function addTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -139,7 +139,7 @@ final class StreamSelectLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, callable $callback)
+    public function addPeriodicTimer($interval, $callback)
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -153,12 +153,12 @@ final class StreamSelectLoop implements LoopInterface
         $this->timers->cancel($timer);
     }
 
-    public function futureTick(callable $listener)
+    public function futureTick($listener)
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, callable $listener)
+    public function addSignal($signal, $listener)
     {
         if ($this->pcntl === false) {
             throw new \BadMethodCallException('Event loop feature "signals" isn\'t supported by the "StreamSelectLoop"');
@@ -167,7 +167,7 @@ final class StreamSelectLoop implements LoopInterface
         $this->signals->add($signal, $listener);
     }
 
-    public function removeSignal($signal, callable $listener)
+    public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
     }

--- a/src/Tick/FutureTickQueue.php
+++ b/src/Tick/FutureTickQueue.php
@@ -28,7 +28,7 @@ final class FutureTickQueue
      *
      * @param callable $listener The callback to invoke.
      */
-    public function add(callable $listener)
+    public function add($listener)
     {
         $this->queue->enqueue($listener);
     }

--- a/src/Timer/Timer.php
+++ b/src/Timer/Timer.php
@@ -25,7 +25,7 @@ final class Timer implements TimerInterface
      * @param callable      $callback The callback that will be executed when this timer elapses
      * @param bool          $periodic Whether the time is periodic
      */
-    public function __construct($interval, callable $callback, $periodic = false)
+    public function __construct($interval, $callback, $periodic = false)
     {
         if ($interval < self::MIN_INTERVAL) {
             $interval = self::MIN_INTERVAL;


### PR DESCRIPTION
I'm filing this PR as an RFC to see if it makes sense to drop these type hints.