### PR TITLE
Improve test suite to be less fragile

### DIFF
--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -262,6 +262,8 @@ abstract class AbstractLoopTest extends TestCase
         // remove a valid stream from the event loop that was never added in the first place
         $this->loop->removeReadStream($stream);
         $this->loop->removeWriteStream($stream);
+
+        $this->assertTrue(true);
     }
 
     /** @test */

--- a/tests/Timer/AbstractTimerTest.php
+++ b/tests/Timer/AbstractTimerTest.php
@@ -8,69 +8,103 @@ abstract class AbstractTimerTest extends TestCase
 {
     abstract public function createLoop();
 
-    public function testAddTimer()
+    public function testAddTimerReturnsNonPeriodicTimerInstance()
     {
-        // usleep is intentionally high
+        $loop = $this->createLoop();
 
+        $timer = $loop->addTimer(0.001, $this->expectCallableNever());
+
+        $this->assertInstanceOf('React\EventLoop\TimerInterface', $timer);
+        $this->assertFalse($timer->isPeriodic());
+    }
+
+    public function testAddTimerWillBeInvokedOnceAndBlocksLoopWhenRunning()
+    {
         $loop = $this->createLoop();
 
         $loop->addTimer(0.001, $this->expectCallableOnce());
-        usleep(1000);
-        $this->tickLoop($loop);
+
+        $start = microtime(true);
+        $loop->run();
+        $end = microtime(true);
+
+        // make no strict assumptions about actual time interval.
+        // must be at least 0.001s (1ms) and should not take longer than 0.1s
+        $this->assertGreaterThanOrEqual(0.001, $end - $start);
+        $this->assertLessThan(0.1, $end - $start);
     }
 
-    public function testAddPeriodicTimer()
+    public function testAddPeriodicTimerReturnsPeriodicTimerInstance()
     {
         $loop = $this->createLoop();
 
-        $loop->addPeriodicTimer(0.001, $this->expectCallableExactly(3));
-        usleep(1000);
-        $this->tickLoop($loop);
-        usleep(1000);
-        $this->tickLoop($loop);
-        usleep(1000);
-        $this->tickLoop($loop);
+        $periodic = $loop->addPeriodicTimer(0.1, $this->expectCallableNever());
+
+        $this->assertInstanceOf('React\EventLoop\TimerInterface', $periodic);
+        $this->assertTrue($periodic->isPeriodic());
     }
 
-    public function testAddPeriodicTimerWithCancel()
+    public function testAddPeriodicTimerWillBeInvokedUntilItIsCancelled()
     {
         $loop = $this->createLoop();
 
-        $timer = $loop->addPeriodicTimer(0.001, $this->expectCallableExactly(2));
+        $periodic = $loop->addPeriodicTimer(0.1, $this->expectCallableExactly(3));
 
-        usleep(1000);
-        $this->tickLoop($loop);
-        usleep(1000);
-        $this->tickLoop($loop);
+        // make no strict assumptions about actual time interval.
+        // leave some room to ensure this ticks exactly 3 times.
+        $loop->addTimer(0.399, function () use ($loop, $periodic) {
+            $loop->cancelTimer($periodic);
+        });
 
-        $loop->cancelTimer($timer);
+        $loop->run();
+    }
 
-        usleep(1000);
-        $this->tickLoop($loop);
+    public function testAddPeriodicTimerWillBeInvokedWithMaximumAccuracyUntilItIsCancelled()
+    {
+        $loop = $this->createLoop();
+
+        $i = 0;
+        $periodic = $loop->addPeriodicTimer(0.001, function () use (&$i) {
+            ++$i;
+        });
+
+        $loop->addTimer(0.02, function () use ($loop, $periodic) {
+            $loop->cancelTimer($periodic);
+        });
+
+        $loop->run();
+
+        // make no strict assumptions about number of invocations.
+        // we know it must be no more than 20 times and should at least be
+        // invoked twice for really slow loops
+        $this->assertLessThanOrEqual(20, $i);
+        $this->assertGreaterThan(2, $i);
     }
 
     public function testAddPeriodicTimerCancelsItself()
     {
-        $i = 0;
-
         $loop = $this->createLoop();
 
+        $i = 0;
         $loop->addPeriodicTimer(0.001, function ($timer) use (&$i, $loop) {
             $i++;
 
-            if ($i == 2) {
+            if ($i === 5) {
                 $loop->cancelTimer($timer);
             }
         });
 
-        usleep(1000);
-        $this->tickLoop($loop);
-        usleep(1000);
-        $this->tickLoop($loop);
-        usleep(1000);
-        $this->tickLoop($loop);
+        $start = microtime(true);
+        $loop->run();
+        $end = microtime(true);
 
-        $this->assertSame(2, $i);
+        $this->assertEquals(5, $i);
+
+        // make no strict assumptions about time interval.
+        // 5 invocations must take at least 0.005s (5ms) and should not take
+        // longer than 0.1s for slower loops.
+        $this->assertGreaterThanOrEqual(0.005, $end - $start);
+        $this->assertLessThan(0.1, $end - $start);
     }
 
     public function testMinimumIntervalOneMicrosecond()

--- a/tests/Timer/TimersTest.php
+++ b/tests/Timer/TimersTest.php
@@ -25,5 +25,7 @@ class TimersTest extends TestCase
         }));
 
         $timers->tick();
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
This simple PR improves the test suite to use less fragile assumptions for the timer tests and avoids related warnings about "risky" tests by PHPUnit.

The old test suite works fine on Travis, but reports these "risky" tests. For some reason, the test suite failed on my local machine when using `ext-event`, despite using same PHP version, same PECL version and same composer packages as seen on Travis: https://gist.github.com/clue/8216c7494769d31dd0c6279a0a27ed7b

The updated test suite avoids blocking the loop and thus makes these tests less fragile.

Builds on top of #138 and #120