### PR TITLE
Refactor and simplify signal handling logic

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -149,14 +149,7 @@ final class ExtEventLoop implements LoopInterface
         $this->signals->add($signal, $listener);
 
         if (!isset($this->signalEvents[$signal])) {
-            $this->signalEvents[$signal] = Event::signal($this->eventBase, $signal, $f = function () use ($signal, &$f) {
-                $this->signals->call($signal);
-                // Ensure there are two copies of the callable around until it has been executed.
-                // For more information see: https://bugs.php.net/bug.php?id=62452
-                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                $g = $f;
-                $f = $g;
-            });
+            $this->signalEvents[$signal] = Event::signal($this->eventBase, $signal, array($this->signals, 'call'));
             $this->signalEvents[$signal]->add();
         }
     }

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -41,21 +41,7 @@ final class ExtEventLoop implements LoopInterface
         $this->eventBase = new EventBase($config);
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-
-        $this->signals = new SignalsHandler(
-            $this,
-            function ($signal) {
-                $this->signalEvents[$signal] = Event::signal($this->eventBase, $signal, $f = function () use ($signal, &$f) {
-                    $this->signals->call($signal);
-                    // Ensure there are two copies of the callable around until it has been executed.
-                    // For more information see: https://bugs.php.net/bug.php?id=62452
-                    // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                    $g = $f;
-                    $f = $g;
-                });
-                $this->signalEvents[$signal]->add();
-            }
-        );
+        $this->signals = new SignalsHandler($this);
 
         $this->createTimerCallback();
         $this->createStreamCallback();
@@ -161,6 +147,18 @@ final class ExtEventLoop implements LoopInterface
     public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
+
+        if (!isset($this->signalEvents[$signal])) {
+            $this->signalEvents[$signal] = Event::signal($this->eventBase, $signal, $f = function () use ($signal, &$f) {
+                $this->signals->call($signal);
+                // Ensure there are two copies of the callable around until it has been executed.
+                // For more information see: https://bugs.php.net/bug.php?id=62452
+                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
+                $g = $f;
+                $f = $g;
+            });
+            $this->signalEvents[$signal]->add();
+        }
     }
 
     public function removeSignal($signal, $listener)

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -41,7 +41,7 @@ final class ExtEventLoop implements LoopInterface
         $this->eventBase = new EventBase($config);
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-        $this->signals = new SignalsHandler($this);
+        $this->signals = new SignalsHandler();
 
         $this->createTimerCallback();
         $this->createStreamCallback();
@@ -181,7 +181,7 @@ final class ExtEventLoop implements LoopInterface
             $flags = EventBase::LOOP_ONCE;
             if (!$this->running || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EventBase::LOOP_NONBLOCK;
-            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count()) {
+            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count() && $this->signals->isEmpty()) {
                 break;
             }
 

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -54,12 +54,6 @@ final class ExtEventLoop implements LoopInterface
                     $f = $g;
                 });
                 $this->signalEvents[$signal]->add();
-            },
-            function ($signal) {
-                if ($this->signals->count($signal) === 0) {
-                    $this->signalEvents[$signal]->free();
-                    unset($this->signalEvents[$signal]);
-                }
             }
         );
 
@@ -172,6 +166,11 @@ final class ExtEventLoop implements LoopInterface
     public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
+
+        if (isset($this->signalEvents[$signal]) && $this->signals->count($signal) === 0) {
+            $this->signalEvents[$signal]->free();
+            unset($this->signalEvents[$signal]);
+        }
     }
 
     public function run()

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -39,7 +39,7 @@ final class ExtLibevLoop implements LoopInterface
         $this->loop = new EventLoop();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-        $this->signals = new SignalsHandler($this);
+        $this->signals = new SignalsHandler();
     }
 
     public function addReadStream($stream, $listener)
@@ -181,7 +181,7 @@ final class ExtLibevLoop implements LoopInterface
             $flags = EventLoop::RUN_ONCE;
             if (!$this->running || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EventLoop::RUN_NOWAIT;
-            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count()) {
+            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count() && $this->signals->isEmpty()) {
                 break;
             }
 

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -148,13 +148,8 @@ final class ExtLibevLoop implements LoopInterface
         $this->signals->add($signal, $listener);
 
         if (!isset($this->signalEvents[$signal])) {
-            $this->signalEvents[$signal] = new SignalEvent($f = function () use ($signal, &$f) {
+            $this->signalEvents[$signal] = new SignalEvent(function () use ($signal) {
                 $this->signals->call($signal);
-                // Ensure there are two copies of the callable around until it has been executed.
-                // For more information see: https://bugs.php.net/bug.php?id=62452
-                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                $g = $f;
-                $f = $g;
             }, $signal);
             $this->loop->add($this->signalEvents[$signal]);
         }

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -39,21 +39,7 @@ final class ExtLibevLoop implements LoopInterface
         $this->loop = new EventLoop();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-
-        $this->signals = new SignalsHandler(
-            $this,
-            function ($signal) {
-                $this->signalEvents[$signal] = new SignalEvent($f = function () use ($signal, &$f) {
-                    $this->signals->call($signal);
-                    // Ensure there are two copies of the callable around until it has been executed.
-                    // For more information see: https://bugs.php.net/bug.php?id=62452
-                    // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                    $g = $f;
-                    $f = $g;
-                }, $signal);
-                $this->loop->add($this->signalEvents[$signal]);
-            }
-        );
+        $this->signals = new SignalsHandler($this);
     }
 
     public function addReadStream($stream, $listener)
@@ -160,6 +146,18 @@ final class ExtLibevLoop implements LoopInterface
     public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
+
+        if (!isset($this->signalEvents[$signal])) {
+            $this->signalEvents[$signal] = new SignalEvent($f = function () use ($signal, &$f) {
+                $this->signals->call($signal);
+                // Ensure there are two copies of the callable around until it has been executed.
+                // For more information see: https://bugs.php.net/bug.php?id=62452
+                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
+                $g = $f;
+                $f = $g;
+            }, $signal);
+            $this->loop->add($this->signalEvents[$signal]);
+        }
     }
 
     public function removeSignal($signal, $listener)

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -52,13 +52,6 @@ final class ExtLibevLoop implements LoopInterface
                     $f = $g;
                 }, $signal);
                 $this->loop->add($this->signalEvents[$signal]);
-            },
-            function ($signal) {
-                if ($this->signals->count($signal) === 0) {
-                    $this->signalEvents[$signal]->stop();
-                    $this->loop->remove($this->signalEvents[$signal]);
-                    unset($this->signalEvents[$signal]);
-                }
             }
         );
     }
@@ -172,6 +165,12 @@ final class ExtLibevLoop implements LoopInterface
     public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
+
+        if (isset($this->signalEvents[$signal]) && $this->signals->count($signal) === 0) {
+            $this->signalEvents[$signal]->stop();
+            $this->loop->remove($this->signalEvents[$signal]);
+            unset($this->signalEvents[$signal]);
+        }
     }
 
     public function run()

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -55,7 +55,7 @@ final class ExtLibeventLoop implements LoopInterface
         $this->eventBase = event_base_new();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-        $this->signals = new SignalsHandler($this);
+        $this->signals = new SignalsHandler();
 
         $this->createTimerCallback();
         $this->createStreamCallback();
@@ -199,7 +199,7 @@ final class ExtLibeventLoop implements LoopInterface
             $flags = EVLOOP_ONCE;
             if (!$this->running || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EVLOOP_NONBLOCK;
-            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count()) {
+            } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count() && $this->signals->isEmpty()) {
                 break;
             }
 

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -165,14 +165,7 @@ final class ExtLibeventLoop implements LoopInterface
 
         if (!isset($this->signalEvents[$signal])) {
             $this->signalEvents[$signal] = event_new();
-            event_set($this->signalEvents[$signal], $signal, EV_PERSIST | EV_SIGNAL, $f = function () use ($signal, &$f) {
-                $this->signals->call($signal);
-                // Ensure there are two copies of the callable around until it has been executed.
-                // For more information see: https://bugs.php.net/bug.php?id=62452
-                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                $g = $f;
-                $f = $g;
-            });
+            event_set($this->signalEvents[$signal], $signal, EV_PERSIST | EV_SIGNAL, array($this->signals, 'call'));
             event_base_set($this->signalEvents[$signal], $this->eventBase);
             event_add($this->signalEvents[$signal]);
         }

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -70,13 +70,6 @@ final class ExtLibeventLoop implements LoopInterface
                 });
                 event_base_set($this->signalEvents[$signal], $this->eventBase);
                 event_add($this->signalEvents[$signal]);
-            },
-            function ($signal) {
-                if ($this->signals->count($signal) === 0) {
-                    event_del($this->signalEvents[$signal]);
-                    event_free($this->signalEvents[$signal]);
-                    unset($this->signalEvents[$signal]);
-                }
             }
         );
 
@@ -190,6 +183,12 @@ final class ExtLibeventLoop implements LoopInterface
     public function removeSignal($signal, $listener)
     {
         $this->signals->remove($signal, $listener);
+
+        if (isset($this->signalEvents[$signal]) && $this->signals->count($signal) === 0) {
+            event_del($this->signalEvents[$signal]);
+            event_free($this->signalEvents[$signal]);
+            unset($this->signalEvents[$signal]);
+        }
     }
 
     public function run()

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -55,23 +55,7 @@ final class ExtLibeventLoop implements LoopInterface
         $this->eventBase = event_base_new();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
-
-        $this->signals = new SignalsHandler(
-            $this,
-            function ($signal) {
-                $this->signalEvents[$signal] = event_new();
-                event_set($this->signalEvents[$signal], $signal, EV_PERSIST | EV_SIGNAL, $f = function () use ($signal, &$f) {
-                    $this->signals->call($signal);
-                    // Ensure there are two copies of the callable around until it has been executed.
-                    // For more information see: https://bugs.php.net/bug.php?id=62452
-                    // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                    $g = $f;
-                    $f = $g;
-                });
-                event_base_set($this->signalEvents[$signal], $this->eventBase);
-                event_add($this->signalEvents[$signal]);
-            }
-        );
+        $this->signals = new SignalsHandler($this);
 
         $this->createTimerCallback();
         $this->createStreamCallback();
@@ -178,6 +162,20 @@ final class ExtLibeventLoop implements LoopInterface
     public function addSignal($signal, $listener)
     {
         $this->signals->add($signal, $listener);
+
+        if (!isset($this->signalEvents[$signal])) {
+            $this->signalEvents[$signal] = event_new();
+            event_set($this->signalEvents[$signal], $signal, EV_PERSIST | EV_SIGNAL, $f = function () use ($signal, &$f) {
+                $this->signals->call($signal);
+                // Ensure there are two copies of the callable around until it has been executed.
+                // For more information see: https://bugs.php.net/bug.php?id=62452
+                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
+                $g = $f;
+                $f = $g;
+            });
+            event_base_set($this->signalEvents[$signal], $this->eventBase);
+            event_add($this->signalEvents[$signal]);
+        }
     }
 
     public function removeSignal($signal, $listener)

--- a/src/SignalsHandler.php
+++ b/src/SignalsHandler.php
@@ -7,24 +7,10 @@ namespace React\EventLoop;
  */
 final class SignalsHandler
 {
-    private $loop;
-    private $timer;
     private $signals = [];
-
-    public function __construct(LoopInterface $loop)
-    {
-        $this->loop = $loop;
-    }
 
     public function add($signal, $listener)
     {
-        if (empty($this->signals) && $this->timer === null) {
-            /**
-             * Timer to keep the loop alive as long as there are any signal handlers registered
-             */
-            $this->timer = $this->loop->addPeriodicTimer(300, function () {});
-        }
-
         if (!isset($this->signals[$signal])) {
             $this->signals[$signal] = [];
         }
@@ -48,11 +34,6 @@ final class SignalsHandler
         if (isset($this->signals[$signal]) && \count($this->signals[$signal]) === 0) {
             unset($this->signals[$signal]);
         }
-
-        if (empty($this->signals) && $this->timer instanceof TimerInterface) {
-            $this->loop->cancelTimer($this->timer);
-            $this->timer = null;
-        }
     }
 
     public function call($signal)
@@ -73,5 +54,10 @@ final class SignalsHandler
         }
 
         return \count($this->signals[$signal]);
+    }
+
+    public function isEmpty()
+    {
+        return !$this->signals;
     }
 }

--- a/src/SignalsHandler.php
+++ b/src/SignalsHandler.php
@@ -10,12 +10,10 @@ final class SignalsHandler
     private $loop;
     private $timer;
     private $signals = [];
-    private $on;
 
-    public function __construct(LoopInterface $loop, $on)
+    public function __construct(LoopInterface $loop)
     {
         $this->loop = $loop;
-        $this->on = $on;
     }
 
     public function add($signal, $listener)
@@ -29,9 +27,6 @@ final class SignalsHandler
 
         if (!isset($this->signals[$signal])) {
             $this->signals[$signal] = [];
-
-            $on = $this->on;
-            $on($signal);
         }
 
         if (in_array($listener, $this->signals[$signal])) {

--- a/src/SignalsHandler.php
+++ b/src/SignalsHandler.php
@@ -11,21 +11,11 @@ final class SignalsHandler
     private $timer;
     private $signals = [];
     private $on;
-    private $off;
 
-    public function __construct(LoopInterface $loop, $on, $off)
+    public function __construct(LoopInterface $loop, $on)
     {
         $this->loop = $loop;
         $this->on = $on;
-        $this->off = $off;
-    }
-
-    public function __destruct()
-    {
-        $off = $this->off;
-        foreach ($this->signals as $signal => $listeners) {
-            $off($signal);
-        }
     }
 
     public function add($signal, $listener)
@@ -62,9 +52,6 @@ final class SignalsHandler
 
         if (isset($this->signals[$signal]) && \count($this->signals[$signal]) === 0) {
             unset($this->signals[$signal]);
-
-            $off = $this->off;
-            $off($signal);
         }
 
         if (empty($this->signals) && $this->timer instanceof TimerInterface) {

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -69,7 +69,7 @@ final class StreamSelectLoop implements LoopInterface
         $this->futureTickQueue = new FutureTickQueue();
         $this->timers = new Timers();
         $this->pcntl = extension_loaded('pcntl');
-        $this->signals = new SignalsHandler($this);
+        $this->signals = new SignalsHandler();
     }
 
     public function addReadStream($stream, $listener)
@@ -200,8 +200,8 @@ final class StreamSelectLoop implements LoopInterface
                     $timeout = $timeout > PHP_INT_MAX ? PHP_INT_MAX : (int)$timeout;
                 }
 
-            // The only possible event is stream activity, so wait forever ...
-            } elseif ($this->readStreams || $this->writeStreams) {
+            // The only possible event is stream or signal activity, so wait forever ...
+            } elseif ($this->readStreams || $this->writeStreams || !$this->signals->isEmpty()) {
                 $timeout = null;
 
             // There's nothing left to do ...

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -80,11 +80,6 @@ final class StreamSelectLoop implements LoopInterface
                     $g = $f;
                     $f = $g;
                 });
-            },
-            function ($signal) {
-                if ($this->signals->count($signal) === 0) {
-                    \pcntl_signal($signal, SIG_DFL);
-                }
             }
         );
     }
@@ -168,7 +163,15 @@ final class StreamSelectLoop implements LoopInterface
 
     public function removeSignal($signal, $listener)
     {
+        if (!$this->signals->count($signal)) {
+            return;
+        }
+
         $this->signals->remove($signal, $listener);
+
+        if ($this->signals->count($signal) === 0) {
+            \pcntl_signal($signal, SIG_DFL);
+        }
     }
 
     public function run()

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -150,14 +150,7 @@ final class StreamSelectLoop implements LoopInterface
         $this->signals->add($signal, $listener);
 
         if ($first) {
-            \pcntl_signal($signal, $f = function ($signal) use (&$f) {
-                $this->signals->call($signal);
-                // Ensure there are two copies of the callable around until it has been executed.
-                // For more information see: https://bugs.php.net/bug.php?id=62452
-                // Only an issue for PHP 5, this hack can be removed once PHP 5 support has been dropped.
-                $g = $f;
-                $f = $g;
-            });
+            \pcntl_signal($signal, array($this->signals, 'call'));
         }
     }
 

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -475,6 +475,12 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->run();
     }
 
+    public function testRemoveSignalNotRegisteredIsNoOp()
+    {
+        $this->loop->removeSignal(SIGINT, function () { });
+        $this->assertTrue(true);
+    }
+
     public function testSignal()
     {
         if (!function_exists('posix_kill') || !function_exists('posix_getpid')) {

--- a/tests/SignalsHandlerTest.php
+++ b/tests/SignalsHandlerTest.php
@@ -11,7 +11,6 @@ final class SignalsHandlerTest extends TestCase
     {
         $callCount = 0;
         $onCount = 0;
-        $offCount = 0;
         $func = function () use (&$callCount) {
             $callCount++;
         };
@@ -19,74 +18,58 @@ final class SignalsHandlerTest extends TestCase
             Factory::create(),
             function () use (&$onCount) {
                 $onCount++;
-            },
-            function () use (&$offCount) {
-                $offCount++;
             }
         );
 
         $this->assertSame(0, $callCount);
         $this->assertSame(0, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
         $this->assertSame(1, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
         $this->assertSame(1, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
         $this->assertSame(1, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->call(SIGUSR1);
         $this->assertSame(1, $callCount);
         $this->assertSame(1, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->add(SIGUSR2, $func);
         $this->assertSame(1, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->add(SIGUSR2, $func);
         $this->assertSame(1, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->call(SIGUSR2);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(0, $offCount);
 
         $signals->remove(SIGUSR2, $func);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(1, $offCount);
 
         $signals->remove(SIGUSR2, $func);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(1, $offCount);
 
         $signals->call(SIGUSR2);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(1, $offCount);
 
         $signals->remove(SIGUSR1, $func);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(2, $offCount);
 
         $signals->call(SIGUSR1);
         $this->assertSame(2, $callCount);
         $this->assertSame(2, $onCount);
-        $this->assertSame(2, $offCount);
     }
 }

--- a/tests/SignalsHandlerTest.php
+++ b/tests/SignalsHandlerTest.php
@@ -10,66 +10,49 @@ final class SignalsHandlerTest extends TestCase
     public function testEmittedEventsAndCallHandling()
     {
         $callCount = 0;
-        $onCount = 0;
         $func = function () use (&$callCount) {
             $callCount++;
         };
         $signals = new SignalsHandler(
-            Factory::create(),
-            function () use (&$onCount) {
-                $onCount++;
-            }
+            Factory::create()
         );
 
         $this->assertSame(0, $callCount);
-        $this->assertSame(0, $onCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
-        $this->assertSame(1, $onCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
-        $this->assertSame(1, $onCount);
 
         $signals->add(SIGUSR1, $func);
         $this->assertSame(0, $callCount);
-        $this->assertSame(1, $onCount);
 
         $signals->call(SIGUSR1);
         $this->assertSame(1, $callCount);
-        $this->assertSame(1, $onCount);
 
         $signals->add(SIGUSR2, $func);
         $this->assertSame(1, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->add(SIGUSR2, $func);
         $this->assertSame(1, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->call(SIGUSR2);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->remove(SIGUSR2, $func);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->remove(SIGUSR2, $func);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->call(SIGUSR2);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->remove(SIGUSR1, $func);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
 
         $signals->call(SIGUSR1);
         $this->assertSame(2, $callCount);
-        $this->assertSame(2, $onCount);
     }
 }

--- a/tests/SignalsHandlerTest.php
+++ b/tests/SignalsHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace React\Tests\EventLoop;
 
-use React\EventLoop\Factory;
 use React\EventLoop\SignalsHandler;
 
 final class SignalsHandlerTest extends TestCase
@@ -13,9 +12,7 @@ final class SignalsHandlerTest extends TestCase
         $func = function () use (&$callCount) {
             $callCount++;
         };
-        $signals = new SignalsHandler(
-            Factory::create()
-        );
+        $signals = new SignalsHandler();
 
         $this->assertSame(0, $callCount);
 


### PR DESCRIPTION
This PR refactors some of the internal signal handling logic. It avoids a number of circular references to avoid relying on GC collecting cycles. It does not affect the public API, this is internal only.

Builds on top of #104 and #149