### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+# - 5.3 # requires old distro, see below
   - 5.4
   - 5.5
   - 5.6
@@ -13,6 +14,9 @@ php:
 dist: trusty
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: hhvm
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ A `stream_select()` based event loop.
 This uses the [`stream_select()`](http://php.net/manual/en/function.stream-select.php)
 function and is the only implementation which works out of the box with PHP.
 
-This event loop works out of the box on PHP 5.4 through PHP 7+ and HHVM.
+This event loop works out of the box on PHP 5.3 through PHP 7+ and HHVM.
 This means that no installation is required and this library works on all
 platforms and supported PHP versions.
 Accordingly, the [`Factory`](#factory) will use this event loop by default if
@@ -574,7 +574,7 @@ $ composer require react/event-loop
 ```
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["event-loop", "asynchronous"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"

--- a/src/SignalsHandler.php
+++ b/src/SignalsHandler.php
@@ -7,12 +7,12 @@ namespace React\EventLoop;
  */
 final class SignalsHandler
 {
-    private $signals = [];
+    private $signals = array();
 
     public function add($signal, $listener)
     {
         if (!isset($this->signals[$signal])) {
-            $this->signals[$signal] = [];
+            $this->signals[$signal] = array();
         }
 
         if (in_array($listener, $this->signals[$signal])) {

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -56,10 +56,10 @@ final class StreamSelectLoop implements LoopInterface
 
     private $futureTickQueue;
     private $timers;
-    private $readStreams = [];
-    private $readListeners = [];
-    private $writeStreams = [];
-    private $writeListeners = [];
+    private $readStreams = array();
+    private $readListeners = array();
+    private $writeStreams = array();
+    private $writeListeners = array();
     private $running;
     private $pcntl = false;
     private $signals;

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -39,11 +39,11 @@ class StreamSelectLoopTest extends AbstractLoopTest
 
     public function signalProvider()
     {
-        return [
-            ['SIGUSR1'],
-            ['SIGHUP'],
-            ['SIGTERM'],
-        ];
+        return array(
+            array('SIGUSR1'),
+            array('SIGHUP'),
+            array('SIGTERM'),
+        );
     }
 
     /**
@@ -60,8 +60,9 @@ class StreamSelectLoopTest extends AbstractLoopTest
         $check = $this->loop->addPeriodicTimer(0.01, function() {
             pcntl_signal_dispatch();
         });
-        $this->loop->addTimer(0.1, function () use ($check) {
-            $this->loop->cancelTimer($check);
+        $loop = $this->loop;
+        $loop->addTimer(0.1, function () use ($check, $loop) {
+            $loop->cancelTimer($check);
         });
 
         $handled = false;
@@ -92,12 +93,13 @@ class StreamSelectLoopTest extends AbstractLoopTest
         });
 
         // add stream to the loop
+        $loop = $this->loop;
         list($writeStream, $readStream) = $this->createSocketPair();
-        $this->loop->addReadStream($readStream, function ($stream) {
+        $loop->addReadStream($readStream, function ($stream) use ($loop) {
             /** @var $loop LoopInterface */
             $read = fgets($stream);
             if ($read === "end loop\n") {
-                $this->loop->stop();
+                $loop->stop();
             }
         });
         $this->loop->addTimer(0.1, function() use ($writeStream) {

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -6,7 +6,9 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
       "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
 
     # install 'event' PHP extension
-    echo "yes" | pecl install event
+    if [[ "$TRAVIS_PHP_VERSION" != "5.3" ]]; then
+        echo "yes" | pecl install event
+    fi
 
     # install 'libevent' PHP extension (does not support php 7)
     if [[ "$TRAVIS_PHP_VERSION" != "7.0" &&


### PR DESCRIPTION
Because _why not_… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting _significant amount_ of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually _require_ any new language features or some external lib, then I'm all for dropping support again. If you want to discuss this further, I would suggest directing this to https://github.com/reactphp/react/issues/374 instead 👍 
