### PR TITLE
Throw BadMethodCallException on manual loop creating when required extension isn't installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You should use the [`Factory`](#factory) to automatically create a new instance.
 Advanced! If you explicitly need a certain event loop implementation, you can
 manually instantiate one of the following classes.
 Note that you may have to install the required PHP extensions for the respective
-event loop implementation first or this may result in a fatal error.
+event loop implementation first or they will throw a `BadMethodCallException` on creation.
 
 #### StreamSelectLoop
 

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -2,6 +2,7 @@
 
 namespace React\EventLoop;
 
+use BadMethodCallException;
 use Event;
 use EventBase;
 use EventConfig as EventBaseConfig;
@@ -38,6 +39,10 @@ final class ExtEventLoop implements LoopInterface
 
     public function __construct()
     {
+        if (!class_exists('EventBase', false)) {
+            throw new BadMethodCallException('Cannot create ExtEventLoop, ext-event extension missing');
+        }
+
         $config = new EventBaseConfig();
         $config->requireFeatures(EventBaseConfig::FEATURE_FDS);
 

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -2,6 +2,7 @@
 
 namespace React\EventLoop;
 
+use BadMethodCallException;
 use libev\EventLoop;
 use libev\IOEvent;
 use libev\SignalEvent;
@@ -36,6 +37,10 @@ final class ExtLibevLoop implements LoopInterface
 
     public function __construct()
     {
+        if (!class_exists('libev\EventLoop', false)) {
+            throw new BadMethodCallException('Cannot create ExtLibevLoop, ext-libev extension missing');
+        }
+
         $this->loop = new EventLoop();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -2,6 +2,7 @@
 
 namespace React\EventLoop;
 
+use BadMethodCallException;
 use Event;
 use EventBase;
 use React\EventLoop\Tick\FutureTickQueue;
@@ -52,6 +53,10 @@ final class ExtLibeventLoop implements LoopInterface
 
     public function __construct()
     {
+        if (!function_exists('event_base_new')) {
+            throw new BadMethodCallException('Cannot create ExtLibeventLoop, ext-libevent extension missing');
+        }
+
         $this->eventBase = event_base_new();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();


### PR DESCRIPTION
This came up during our [hangouts call today](https://twitter.com/WyriHaximus/status/968594002474946560). At the moment when creating a loop directly when the required extension is missing creating will fail epicly. This proposed PR will throw an `BadMethodCallException` when the required extension is missing.