### PR TITLE
Removed EventConfig constructor argument from ExtEventLoop for consistency

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -4,7 +4,6 @@ namespace React\EventLoop;
 
 use Event;
 use EventBase;
-use EventConfig as EventBaseConfig;
 use React\EventLoop\Tick\FutureTickQueue;
 use React\EventLoop\Timer\Timer;
 use SplObjectStorage;
@@ -36,9 +35,9 @@ final class ExtEventLoop implements LoopInterface
     private $signals;
     private $signalEvents = array();
 
-    public function __construct(EventBaseConfig $config = null)
+    public function __construct()
     {
-        $this->eventBase = new EventBase($config);
+        $this->eventBase = new EventBase();
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();
         $this->signals = new SignalsHandler();

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -16,13 +16,7 @@ class ExtEventLoopTest extends AbstractLoopTest
             $this->markTestSkipped('ext-event tests skipped because ext-event is not installed.');
         }
 
-        $cfg = null;
-        if ($readStreamCompatible) {
-            $cfg = new \EventConfig();
-            $cfg->requireFeatures(\EventConfig::FEATURE_FDS);
-        }
-
-        return new ExtEventLoop($cfg);
+        return new ExtEventLoop();
     }
 
     public function createStream()
@@ -61,30 +55,5 @@ class ExtEventLoopTest extends AbstractLoopTest
         }
 
         fwrite($stream, $content);
-    }
-
-    /**
-     * @group epoll-readable-error
-     */
-    public function testCanUseReadableStreamWithFeatureFds()
-    {
-        if (PHP_VERSION_ID > 70000) {
-            $this->markTestSkipped('Memory stream not supported');
-        }
-
-        $this->loop = $this->createLoop(true);
-
-        $input = fopen('php://temp/maxmemory:0', 'r+');
-
-        fwrite($input, 'x');
-        ftruncate($input, 0);
-
-        $this->loop->addReadStream($input, $this->expectCallableExactly(2));
-
-        fwrite($input, "foo\n");
-        $this->tickLoop($this->loop);
-
-        fwrite($input, "bar\n");
-        $this->tickLoop($this->loop);
     }
 }


### PR DESCRIPTION
Mutually exclusive with #156

This came up during a discussion, filed for discussion.