### PR TITLE
ExtEventLoop: Remove optional EventBaseConfig and make FEATURE_FDS enabled by default

### DIFF
--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -38,6 +38,11 @@ final class ExtEventLoop implements LoopInterface
 
     public function __construct(EventBaseConfig $config = null)
     {
+        if ($config === null) {
+            $config = new EventBaseConfig();
+            $config->requireFeatures(EventBaseConfig::FEATURE_FDS);
+        }
+
         $this->eventBase = new EventBase($config);
         $this->futureTickQueue = new FutureTickQueue();
         $this->timerEvents = new SplObjectStorage();

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -36,12 +36,10 @@ final class ExtEventLoop implements LoopInterface
     private $signals;
     private $signalEvents = array();
 
-    public function __construct(EventBaseConfig $config = null)
+    public function __construct()
     {
-        if ($config === null) {
-            $config = new EventBaseConfig();
-            $config->requireFeatures(EventBaseConfig::FEATURE_FDS);
-        }
+        $config = new EventBaseConfig();
+        $config->requireFeatures(EventBaseConfig::FEATURE_FDS);
 
         $this->eventBase = new EventBase($config);
         $this->futureTickQueue = new FutureTickQueue();

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -16,13 +16,7 @@ class ExtEventLoopTest extends AbstractLoopTest
             $this->markTestSkipped('ext-event tests skipped because ext-event is not installed.');
         }
 
-        $cfg = null;
-        if ($readStreamCompatible) {
-            $cfg = new \EventConfig();
-            $cfg->requireFeatures(\EventConfig::FEATURE_FDS);
-        }
-
-        return new ExtEventLoop($cfg);
+        return new ExtEventLoop();
     }
 
     public function createStream()


### PR DESCRIPTION
Mutually exclusive with #154

This came up in a discussion after #154 was filed and because doing this by default will be provide a better BC.