### PR TITLE
Do not suggest installing outdated event loop extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,6 @@
     },
     "suggest": {
         "ext-event": "~1.0 for ExtEventLoop",
-        "ext-libevent": ">=0.1.0 for ExtLibeventLoop and PHP 5 only",
-        "ext-libev": "for ExtLibevLoop and PHP 5 only",
         "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
     },
     "autoload": {


### PR DESCRIPTION
I agree that we want to suggest installing event loop extensions for some use cases (this is covered in #127). However, we probably do not want to suggest installing outdated event loop extensions that are no longer supported on PHP 7. These are a constant source of confusion as they're known to cause SEGFAULTs. This simple PR removes these outdated suggestions.

Builds on top of #127
Resolves / closes #114