### PR TITLE
StreamSelectLoop: Improve memory consumption and runtime performance for timers

### DIFF
--- a/src/Timer/Timers.php
+++ b/src/Timer/Timers.php
@@ -3,8 +3,6 @@
 namespace React\EventLoop\Timer;
 
 use React\EventLoop\TimerInterface;
-use SplObjectStorage;
-use SplPriorityQueue;
 
 /**
  * A scheduler implementation that can hold multiple timer instances
@@ -17,14 +15,8 @@ use SplPriorityQueue;
 final class Timers
 {
     private $time;
-    private $timers;
-    private $scheduler;
-
-    public function __construct()
-    {
-        $this->timers = new SplObjectStorage();
-        $this->scheduler = new SplPriorityQueue();
-    }
+    private $timers = array();
+    private $schedule = array();
 
     public function updateTime()
     {
@@ -38,36 +30,26 @@ final class Timers
 
     public function add(TimerInterface $timer)
     {
-        $interval = $timer->getInterval();
-        $scheduledAt = $interval + microtime(true);
-
-        $this->timers->attach($timer, $scheduledAt);
-        $this->scheduler->insert($timer, -$scheduledAt);
+        $id = spl_object_hash($timer);
+        $this->timers[$id] = $timer;
+        $this->schedule[$id] = $timer->getInterval() + microtime(true);
+        asort($this->schedule);
     }
 
     public function contains(TimerInterface $timer)
     {
-        return $this->timers->contains($timer);
+        return isset($this->timers[spl_oject_hash($timer)]);
     }
 
     public function cancel(TimerInterface $timer)
     {
-        $this->timers->detach($timer);
+        $id = spl_object_hash($timer);
+        unset($this->timers[$id], $this->schedule[$id]);
     }
 
     public function getFirst()
     {
-        while ($this->scheduler->count()) {
-            $timer = $this->scheduler->top();
-
-            if ($this->timers->contains($timer)) {
-                return $this->timers[$timer];
-            }
-
-            $this->scheduler->extract();
-        }
-
-        return null;
+        return reset($this->schedule);
     }
 
     public function isEmpty()
@@ -78,31 +60,27 @@ final class Timers
     public function tick()
     {
         $time = $this->updateTime();
-        $timers = $this->timers;
-        $scheduler = $this->scheduler;
 
-        while (!$scheduler->isEmpty()) {
-            $timer = $scheduler->top();
-
-            if (!isset($timers[$timer])) {
-                $scheduler->extract();
-                $timers->detach($timer);
-
-                continue;
-            }
-
-            if ($timers[$timer] >= $time) {
+        foreach ($this->schedule as $id => $scheduled) {
+            // schedule is ordered, so loop until first timer that is not scheduled for execution now
+            if ($scheduled >= $time) {
                 break;
             }
 
-            $scheduler->extract();
+            // skip any timers that are removed while we process the current schedule
+            if (!isset($this->schedule[$id]) || $this->schedule[$id] !== $scheduled) {
+                continue;
+            }
+
+            $timer = $this->timers[$id];
             call_user_func($timer->getCallback(), $timer);
 
-            if ($timer->isPeriodic() && isset($timers[$timer])) {
-                $timers[$timer] = $scheduledAt = $timer->getInterval() + $time;
-                $scheduler->insert($timer, -$scheduledAt);
+            // re-schedule if this is a periodic timer and it has not been cancelled explicitly already
+            if ($timer->isPeriodic() && isset($this->timers[$id])) {
+                $this->schedule[$id] = $timer->getInterval() + $time;
+                asort($this->schedule);
             } else {
-                $timers->detach($timer);
+                unset($this->timers[$id], $this->schedule[$id]);
             }
         }
     }


### PR DESCRIPTION
While debugging some very *odd memory issues* in a live application, I noticed that the `StreamSelectLoop` does not immediately free all related memory when a timer is cancelled. Let's not call this a "memory leak", because memory was *eventually* freed, but this clearly caused some unexpected and significant memory growth.

In many common programs, adding timeouts to operations is a very fundamental operation. As such, it's common to end up with hundred or thousands of timers which most of the time get cancelled very frequently as a successful execution will quickly cancel outstanding timeouts.

I've used the following script to demonstrate unreasonable memory growth:

```
<?php

use React\EventLoop\Factory;

require __DIR__ . '/../vendor/autoload.php';

$loop = Factory::create();

$loop->addPeriodicTimer(0.00001, function () use ($loop) {
    $timer = $loop->addTimer(60, function () { });
    $loop->cancelTimer($timer);
});

$loop->addPeriodicTimer(1.0, function () use ($loop) {
    echo memory_get_usage() . PHP_EOL;
});

$loop->run();
```

Running this on the current master branch, this peaked at around 320 MB of memory on my system (YMMV). After applying this patch, this script reports a constant memory consumption of around 0.7 MB.

The original implementation internally relied on a `SplPriorityQueue` for fast insertions of new timers, but this class lacks access to actually remove timers. This means that they would actually stay in the queue until they were originally supposed to fire.

This was apparently done for performance reasons, so this patch includes some thorough performance tests. The result here is that adding a large number of timers at the same time shows a significant performance improvement (`time php examples/92-benchmark-timers.php 20000` from 15s down to 2s). Waiting for a large number of timers to fire one after another does not show a noticeable impact (`time php examples/94-benchmark-timers-delay.php 20000` both at around 2.5s). 