### PR TITLE
Dereferencing/referencing of streams and timers

### DIFF
--- a/src/ExtLoopInterface.php
+++ b/src/ExtLoopInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\EventLoop;
+
+/**
+ * Temporary extended loop interface to allow non-BC addition of features.
+ * This interface shall be removed when preparing for event-loop v2.
+ */
+interface ExtLoopInterface extends LoopInterface
+{
+    /**
+     * References a previously dereferenced stream or timer.
+     *
+     * @param resource|TimerInterface
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    public function reference($streamOrTimer);
+    
+    /**
+     * Dereferences a stream or timer.
+     *
+     * A dereferenced stream or timer does not keep the loop
+     * ticking if dereferenced streams or timers are the only
+     * thing that would keep the loop ticking.
+     *
+     * @param resource|TimerInterface
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    public function dereference($streamOrTimer);
+}

--- a/src/Timer/Timers.php
+++ b/src/Timer/Timers.php
@@ -61,7 +61,12 @@ final class Timers
 
     public function isEmpty()
     {
-        return \count($this->timers) === 0;
+        return $this->count() === 0;
+    }
+
+    public function count()
+    {
+        return \count($this->timers);
     }
 
     public function tick()


### PR DESCRIPTION
This PR implements dereferencing and referencing of streams and timers (closes #107).

Signals are deferenced by default and can not be referenced (there is no use case where we only have signal watchers and nothing else (that actively prevents #175), if anything like that is required for some unreal ancient communication cult, plain PHP can do the job too).

To avoid BC, a new loop interface was created which extends the loop interface, to allow implementing new methods. This interface should be removed for v2.0. The new interface trick was suggested by @WyriHaximus.