### PR TITLE
Forward compatibility with PHPUnit 7 and fix false negative test results, use legacy PHPUnit 5 on legacy HHVM, skip signal tests when PCNTL is not available and skip timer tests on inacurrate platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - hhvm # ignore errors, see below
+# - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
@@ -18,6 +18,8 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: hhvm
+      install: composer require phpunit/phpunit:^5 --dev --no-interaction
   allow_failures:
     - php: hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"
+        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "ext-event": "~1.0 for ExtEventLoop",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="React Test Suite">

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -491,10 +491,13 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveSignalNotRegisteredIsNoOp()
     {
-        $this->loop->removeSignal(SIGINT, function () { });
+        $this->loop->removeSignal(2, function () { });
         $this->assertTrue(true);
     }
 
+    /**
+     * @requires extension pcntl
+     */
     public function testSignal()
     {
         if (!function_exists('posix_kill') || !function_exists('posix_getpid')) {
@@ -528,6 +531,9 @@ abstract class AbstractLoopTest extends TestCase
         $this->assertTrue($calledShouldNot);
     }
 
+    /**
+     * @requires extension pcntl
+     */
     public function testSignalMultipleUsagesForTheSameListener()
     {
         $funcCallCount = 0;
@@ -552,6 +558,9 @@ abstract class AbstractLoopTest extends TestCase
         $this->assertSame(1, $funcCallCount);
     }
 
+    /**
+     * @requires extension pcntl
+     */
     public function testSignalsKeepTheLoopRunning()
     {
         $loop = $this->loop;
@@ -565,6 +574,9 @@ abstract class AbstractLoopTest extends TestCase
         $this->assertRunSlowerThan(1.5);
     }
 
+    /**
+     * @requires extension pcntl
+     */
     public function testSignalsKeepTheLoopRunningAndRemovingItStopsTheLoop()
     {
         $loop = $this->loop;

--- a/tests/SignalsHandlerTest.php
+++ b/tests/SignalsHandlerTest.php
@@ -6,6 +6,9 @@ use React\EventLoop\SignalsHandler;
 
 final class SignalsHandlerTest extends TestCase
 {
+    /**
+     * @requires extension pcntl
+     */
     public function testEmittedEventsAndCallHandling()
     {
         $callCount = 0;

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -49,13 +49,10 @@ class StreamSelectLoopTest extends AbstractLoopTest
     /**
      * Test signal interrupt when no stream is attached to the loop
      * @dataProvider signalProvider
+     * @requires extension pcntl
      */
     public function testSignalInterruptNoStream($signal)
     {
-        if (!extension_loaded('pcntl')) {
-            $this->markTestSkipped('"pcntl" extension is required to run this test.');
-        }
-
         // dispatch signal handler every 10ms for 0.1s
         $check = $this->loop->addPeriodicTimer(0.01, function() {
             pcntl_signal_dispatch();
@@ -80,13 +77,10 @@ class StreamSelectLoopTest extends AbstractLoopTest
     /**
      * Test signal interrupt when a stream is attached to the loop
      * @dataProvider signalProvider
+     * @requires extension pcntl
      */
     public function testSignalInterruptWithStream($signal)
     {
-        if (!extension_loaded('pcntl')) {
-            $this->markTestSkipped('"pcntl" extension is required to run this test.');
-        }
-
         // dispatch signal handler every 10ms
         $this->loop->addPeriodicTimer(0.01, function() {
             pcntl_signal_dispatch();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!defined('SIGUSR1')) {
-    define('SIGUSR1', 1);
-}
-
-if (!defined('SIGUSR2')) {
-    define('SIGUSR2', 2);
-}


### PR DESCRIPTION
Builds on top of #120 and clue/php-socket-raw#42