### PR TITLE
Use high resolution timer on PHP 7.3+ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,14 @@ It is commonly installed as part of many PHP distributions.
 If this extension is missing (or you're running on Windows), signal handling is
 not supported and throws a `BadMethodCallException` instead.
 
-This event loop is known to rely on wall-clock time to schedule future
-timers, because a monotonic time source is not available in PHP by default.
+This event loop is known to rely on wall-clock time to schedule future timers
+when using any version before PHP 7.3, because a monotonic time source is
+only available as of PHP 7.3 (`hrtime()`).
 While this does not affect many common use cases, this is an important
 distinction for programs that rely on a high time precision or on systems
 that are subject to discontinuous time adjustments (time jumps).
-This means that if you schedule a timer to trigger in 30s and then adjust
-your system time forward by 20s, the timer may trigger in 10s.
+This means that if you schedule a timer to trigger in 30s on PHP < 7.3 and
+then adjust your system time forward by 20s, the timer may trigger in 10s.
 See also [`addTimer()`](#addtimer) for more details.
 
 #### ExtEventLoop
@@ -360,8 +361,8 @@ same time (within its possible accuracy) is not guaranteed.
 
 This interface suggests that event loop implementations SHOULD use a
 monotonic time source if available. Given that a monotonic time source is
-not available on PHP by default, event loop implementations MAY fall back
-to using wall-clock time.
+only available as of PHP 7.3 by default, event loop implementations MAY
+fall back to using wall-clock time.
 While this does not affect many common use cases, this is an important
 distinction for programs that rely on a high time precision or on systems
 that are subject to discontinuous time adjustments (time jumps).
@@ -433,8 +434,8 @@ same time (within its possible accuracy) is not guaranteed.
 
 This interface suggests that event loop implementations SHOULD use a
 monotonic time source if available. Given that a monotonic time source is
-not available on PHP by default, event loop implementations MAY fall back
-to using wall-clock time.
+only available as of PHP 7.3 by default, event loop implementations MAY
+fall back to using wall-clock time.
 While this does not affect many common use cases, this is an important
 distinction for programs that rely on a high time precision or on systems
 that are subject to discontinuous time adjustments (time jumps).

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -185,8 +185,8 @@ interface LoopInterface
      *
      * This interface suggests that event loop implementations SHOULD use a
      * monotonic time source if available. Given that a monotonic time source is
-     * not available on PHP by default, event loop implementations MAY fall back
-     * to using wall-clock time.
+     * only available as of PHP 7.3 by default, event loop implementations MAY
+     * fall back to using wall-clock time.
      * While this does not affect many common use cases, this is an important
      * distinction for programs that rely on a high time precision or on systems
      * that are subject to discontinuous time adjustments (time jumps).
@@ -263,8 +263,8 @@ interface LoopInterface
      *
      * This interface suggests that event loop implementations SHOULD use a
      * monotonic time source if available. Given that a monotonic time source is
-     * not available on PHP by default, event loop implementations MAY fall back
-     * to using wall-clock time.
+     * only available as of PHP 7.3 by default, event loop implementations MAY
+     * fall back to using wall-clock time.
      * While this does not affect many common use cases, this is an important
      * distinction for programs that rely on a high time precision or on systems
      * that are subject to discontinuous time adjustments (time jumps).

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -38,13 +38,14 @@ use React\EventLoop\Timer\Timers;
  * If this extension is missing (or you're running on Windows), signal handling is
  * not supported and throws a `BadMethodCallException` instead.
  *
- * This event loop is known to rely on wall-clock time to schedule future
- * timers, because a monotonic time source is not available in PHP by default.
+ * This event loop is known to rely on wall-clock time to schedule future timers
+ * when using any version before PHP 7.3, because a monotonic time source is
+ * only available as of PHP 7.3 (`hrtime()`).
  * While this does not affect many common use cases, this is an important
  * distinction for programs that rely on a high time precision or on systems
  * that are subject to discontinuous time adjustments (time jumps).
- * This means that if you schedule a timer to trigger in 30s and then adjust
- * your system time forward by 20s, the timer may trigger in 10s.
+ * This means that if you schedule a timer to trigger in 30s on PHP < 7.3 and
+ * then adjust your system time forward by 20s, the timer may trigger in 10s.
  * See also [`addTimer()`](#addtimer) for more details.
  *
  * @link http://php.net/manual/en/function.stream-select.php

--- a/src/Timer/Timers.php
+++ b/src/Timer/Timers.php
@@ -21,7 +21,12 @@ final class Timers
 
     public function updateTime()
     {
-        return $this->time = \microtime(true);
+        // prefer high-resolution timer, available as of PHP 7.3+
+        if (\function_exists('hrtime')) {
+            return $this->time = \hrtime(true) * 1e-9;
+        }
+
+        return $this->time = \microtime(true) + 1000;
     }
 
     public function getTime()
@@ -33,7 +38,7 @@ final class Timers
     {
         $id = \spl_object_hash($timer);
         $this->timers[$id] = $timer;
-        $this->schedule[$id] = $timer->getInterval() + \microtime(true);
+        $this->schedule[$id] = $timer->getInterval() + $this->updateTime();
         $this->sorted = false;
     }
 

--- a/src/Timer/Timers.php
+++ b/src/Timer/Timers.php
@@ -18,15 +18,17 @@ final class Timers
     private $timers = array();
     private $schedule = array();
     private $sorted = true;
+    private $useHighResolution;
+
+    public function __construct()
+    {
+        // prefer high-resolution timer, available as of PHP 7.3+
+        $this->useHighResolution = \function_exists('hrtime');
+    }
 
     public function updateTime()
     {
-        // prefer high-resolution timer, available as of PHP 7.3+
-        if (\function_exists('hrtime')) {
-            return $this->time = \hrtime(true) * 1e-9;
-        }
-
-        return $this->time = \microtime(true) + 1000;
+        return $this->time = $this->useHighResolution ? \hrtime(true) * 1e-9 : \microtime(true);
     }
 
     public function getTime()


### PR DESCRIPTION
This project suggests that event loop implementations SHOULD use a
monotonic time source if available. Given that a monotonic time source is
only available as of PHP 7.3 by default, event loop implementations MAY
fall back to using wall-clock time. http://php.net/manual/en/function.hrtime.php

Builds on top of #157 and #130
Resolves #73