### PR TITLE
[RFC][WIP] Fork support

### DIFF
--- a/src/ForkableLoopInterface.php
+++ b/src/ForkableLoopInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace React\EventLoop;
+
+interface ForkableLoopInterface extends LoopInterface
+{
+    /**
+     * Create a new event loop after fork
+     *
+     * This will dispose the current loop instance and return a new
+     * stopped event loop instance that can be used within the child
+     * process.
+     *
+     * The child process should call this method or reuseForChildProcess()
+     * right after the fork
+     *
+     * @return ForkableLoopInterface
+     */
+    public function recreateForChildProcess();
+
+    /**
+     * Reinitializes the event loop for re-use in the child process
+     *
+     * This will keep the event loop in tact so that the forked child
+     * can continue using it.
+     *
+     * The child process should call this method or reuseForChildProcess()
+     * right after the fork
+     *
+     * @return void
+     */
+    public function reuseForChildProcess();
+}

--- a/tests/AbstractForkableLoopTest.php
+++ b/tests/AbstractForkableLoopTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace React\Tests\EventLoop;
+
+use React\EventLoop\ForkableLoopInterface;
+
+/**
+ * @method ForkableLoopInterface createLoop()
+ */
+abstract class AbstractForkableLoopTest extends AbstractLoopTest
+{
+    public function testShouldReturnNewLoopOnRecreateForChildProcess()
+    {
+        $loop = $this->createLoop();
+        $new = $loop->recreateForChildProcess();
+
+        $this->assertNotSame($loop, $new);
+    }
+
+    public function testShouldDisposeTheLoopOnRecreateForChild()
+    {
+        $read = fopen('/dev/urandom', 'r');
+        $write = fopen('/dev/null', 'w');
+        $loop = $this->createLoop();
+        $never = $this->expectCallableNever();
+
+        $loop->addReadStream($read, $never);
+        $loop->addWriteStream($write, $never);
+        $loop->addTimer(0.1, $never);
+        $loop->futureTick($never);
+
+        $loop->recreateForChildProcess();
+        $this->tickLoop($loop);
+    }
+
+    public function testShouldStopTheExistingLoopOnRecreateForChildProcess()
+    {
+        $loop = $this->createLoop();
+        $futureTickCalled = false;
+
+        $loop->futureTick(function() use ($loop, &$futureTickCalled) {
+            $loop->recreateForChildProcess();
+
+            $loop->futureTick(function() use ($loop, &$futureTickCalled) {
+                $futureTickCalled = true;
+                $loop->stop();
+            });
+        });
+
+        $this->assertFalse($futureTickCalled);
+    }
+}

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -4,7 +4,12 @@ namespace React\Tests\EventLoop;
 
 use React\EventLoop\ExtEventLoop;
 
-class ExtEventLoopTest extends AbstractLoopTest
+/**
+ * @requires OS Linux
+ * @requires extension event
+ * @requires extension posix
+ */
+class ExtEventLoopTest extends AbstractForkableLoopTest
 {
     public function createLoop($readStreamCompatible = false)
     {
@@ -57,9 +62,6 @@ class ExtEventLoopTest extends AbstractLoopTest
         fwrite($stream, $content);
     }
 
-    /**
-     * @group epoll-readable-error
-     */
     public function testCanUseReadableStreamWithFeatureFds()
     {
         if (PHP_VERSION_ID > 70000) {


### PR DESCRIPTION
At the moment react cannot be used with `pcntl_fork()` out of the box at the moment.

- Reusing the event loop in the child process is not possible (some backends require a re-init)
- Discarting the parent's event loop from within the forked child has some pitfalls
 - The child must stop the loop manually. Not doing so may break.
 - Complete disposal of all references is only possible with reflection. 

This mostly applies to scenarios where a fork is performed when the loop is already running and active. For example from an registered SIGCHLD signal istener.

This PR offers the following proposal to make this possible:

Event loops that support forking will implement `ForkableLoopInterface`. Users can then `instanceof`-check if they can use fork safely.

After calling `pcntl_fork()` the user has two options in the child process:

1. Re-Using the loop with its state (all registered listeners, timers, etc...) by calling `ForkableLoopInterface::reuseForChildProcess().
2. Disposing the existing loop and creating a new one by calling `ForkableLoopInterface::recreateForChildProcess()`. This will detach everything from the loop, stop it and return a new loop instance.

Example for recreate:

```php
$childId = pcntl_fork();

if ($childId === 0) {
    // child, this is a worker, we need a new loop
    $childLoop = $loop->recreateForChildProcess();
    $childLoop->addPeriodicTimer(0.5, new WorkerPollStrategy());
    $childLoop->run();
    exit(0);
}

// ... master
``` 