### PR TITLE
Avoid RuntimeException by making sure that queue is not empty before dequeueing next callback

### DIFF
--- a/src/Tick/FutureTickQueue.php
+++ b/src/Tick/FutureTickQueue.php
@@ -41,7 +41,7 @@ final class FutureTickQueue
         // Only invoke as many callbacks as were on the queue when tick() was called.
         $count = $this->queue->count();
 
-        while ($count--) {
+        while (!$this->queue->isEmpty() && $count--) {
             \call_user_func(
                 $this->queue->dequeue()
             );


### PR DESCRIPTION
The rationale for this change is to fix an issue that was verified when using the ReactPHP HttpClient Adapter for Guzzle6 (wyrihaximus/react-guzzle-psr7) to send requests synchronously (instead of asynchronously, as one would normally do). It turns out that, when the HTTP client adapter is used in a synchronous way, the tick() method of the event loop's future-tick queue is eventually recursively called (a callback from the future-tick queue calls the event loop's run() method, which in turn calls the future-tick queue's tick() method). This recursive call will then eventually deplete the future-tick queue dequeueing all remaining callbacks. When the recursive call returns, the original call to the future-tick queue's tick() method will continue its processing and try to dequeue the callbacks from the now empty queue, which will then trigger the RuntimeException: Can't shift from an empty datastructure.