### PR TITLE
Fix testing ext-uv on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 php:
 # - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
+# - 5.4 # requires old distro, see below
+# - 5.5 # requires old distro, see below
   - 5.6
   - 7.0
   - 7.1
@@ -12,12 +12,16 @@ php:
 # - hhvm # requires legacy phpunit & ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: trusty
+dist: xenial
 
 matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
     - php: hhvm
       install: composer require phpunit/phpunit:^5 --dev --no-interaction
   allow_failures:

--- a/travis-init.sh
+++ b/travis-init.sh
@@ -45,7 +45,8 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" &&
     # install 'libuv' PHP extension (does not support php 5)
     if [[ "$TRAVIS_PHP_VERSION" = "7.0" ||
           "$TRAVIS_PHP_VERSION" = "7.1" ||
-          "$TRAVIS_PHP_VERSION" = "7.2" ]]; then
+          "$TRAVIS_PHP_VERSION" = "7.2"  ||
+          "$TRAVIS_PHP_VERSION" = "7.3" ]]; then
         echo "yes" | pecl install uv-beta
     fi
 


### PR DESCRIPTION
For some reason `libuv1-dev` isn't available anymore on Travis. Had to shuffle the Ubuntu distro's around a bit to get it working again. Also enabled `ext-uv` testing on PHP 7.3 while I was at it.