### PR TITLE
Fix Travis CI builds, do not install libuv on legacy PHP setups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,16 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+      before_install: [] # skip libuv
     - php: 5.4
       dist: trusty
+      before_install: [] # skip libuv
     - php: 5.5
       dist: trusty
+      before_install: [] # skip libuv
     - php: hhvm
       install: composer require phpunit/phpunit:^5 --dev --no-interaction
+      before_install: [] # skip libuv
   allow_failures:
     - php: hhvm
 
@@ -41,7 +45,7 @@ cache:
 before_install:
   - sudo add-apt-repository ppa:ondrej/php -y
   - sudo apt-get update -q
-  - sudo apt-get install libuv1-dev || true
+  - sudo apt-get install libuv1-dev
 
 install:
   - ./travis-init.sh


### PR DESCRIPTION
Builds on top of #197 and https://github.com/clue/reactphp-ami/commit/bfc91b7fe9674291fa5cf85612ef2e273203a8cf
Noticed due to unrelated build error in #201 