### PR TITLE
ExtUvLoop: Fix reporting connection refused errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,20 @@ matrix:
         - php -r "file_put_contents(php_ini_loaded_file(),'extension=event'.PHP_EOL,FILE_APPEND);"
       install:
         - composer install
+    - name: "Windows PHP 7.4 with ext-uv"
+      os: windows
+      language: shell # no built-in php support
+      before_install:
+        - curl -OL https://windows.php.net/downloads/pecl/releases/uv/0.2.4/php_uv-0.2.4-7.4-nts-vc15-x64.zip # latest version as of 2019-12-23
+        - choco install php --version=7.4.0 # latest version supported by ext-uv as of 2019-12-23
+        - choco install composer
+        - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
+        - php -r "\$z=new ZipArchive();\$z->open(glob('php_uv*.zip')[0]);\$z->extractTo(dirname(php_ini_loaded_file()).'/ext','php_uv.dll');\$z->extractTo(dirname(php_ini_loaded_file()),'libuv.dll');"
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension_dir=ext'.PHP_EOL,FILE_APPEND);"
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension=sockets'.PHP_EOL,FILE_APPEND);" # ext-sockets needs to be loaded before ext-uv
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension=uv'.PHP_EOL,FILE_APPEND);"
+      install:
+        - composer install
   allow_failures:
     - php: hhvm
     - os: windows

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\EventLoop;
 
 use React\EventLoop\StreamSelectLoop;
+use React\EventLoop\ExtUvLoop;
 
 abstract class AbstractLoopTest extends TestCase
 {
@@ -144,6 +145,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddReadStream()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
@@ -157,6 +162,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddReadStreamIgnoresSecondCallable()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
@@ -206,6 +215,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddWriteStream()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
@@ -215,6 +228,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddWriteStreamIgnoresSecondCallable()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
@@ -225,6 +242,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveReadStreamInstantly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableNever());
@@ -236,6 +257,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveReadStreamAfterReading()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableOnce());
@@ -251,6 +276,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveWriteStreamInstantly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableNever());
@@ -260,6 +289,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveWriteStreamAfterWriting()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableOnce());
@@ -271,6 +304,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveStreamForReadOnly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableNever());
@@ -283,6 +320,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveStreamForWriteOnly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         fwrite($output, "foo\n");
@@ -505,6 +546,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testFutureTickFiresBeforeIO()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($stream) = $this->createSocketPair();
 
         $this->loop->addWriteStream(
@@ -525,6 +570,9 @@ abstract class AbstractLoopTest extends TestCase
         $this->tickLoop($this->loop);
     }
 
+    /**
+     * @depends testFutureTickFiresBeforeIO
+     */
     public function testRecursiveFutureTick()
     {
         list ($stream) = $this->createSocketPair();


### PR DESCRIPTION
This PR fixes reporting "connection refused" on affected installation of ExtUvLoop. I have started with adding relevant tests to the test matrix, fixing the underlying issue and included additional tests to run run this on Windows as well.

Resolves #188
Builds on top of #205
Refs #206 to skip a similar problem for the `StreamSelectLoop` on Windows only.