### PR TITLE
Fix reporting refused connections with StreamSelectLoop on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,20 @@ matrix:
         - php -r "file_put_contents(php_ini_loaded_file(),'extension=event'.PHP_EOL,FILE_APPEND);"
       install:
         - composer install
+    - name: "Windows PHP 7.4 with ext-uv"
+      os: windows
+      language: shell # no built-in php support
+      before_install:
+        - curl -OL https://windows.php.net/downloads/pecl/releases/uv/0.2.4/php_uv-0.2.4-7.4-nts-vc15-x64.zip # latest version as of 2019-12-23
+        - choco install php --version=7.4.0 # latest version supported by ext-uv as of 2019-12-23
+        - choco install composer
+        - export PATH="$(powershell -Command '("Process", "Machine" | % { [Environment]::GetEnvironmentVariable("PATH", $_) -Split ";" -Replace "\\$", "" } | Select -Unique | % { cygpath $_ }) -Join ":"')"
+        - php -r "\$z=new ZipArchive();\$z->open(glob('php_uv*.zip')[0]);\$z->extractTo(dirname(php_ini_loaded_file()).'/ext','php_uv.dll');\$z->extractTo(dirname(php_ini_loaded_file()),'libuv.dll');"
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension_dir=ext'.PHP_EOL,FILE_APPEND);"
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension=sockets'.PHP_EOL,FILE_APPEND);" # ext-sockets needs to be loaded before ext-uv
+        - php -r "file_put_contents(php_ini_loaded_file(),'extension=uv'.PHP_EOL,FILE_APPEND);"
+      install:
+        - composer install
   allow_failures:
     - php: hhvm
     - os: windows

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -111,16 +111,11 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddWriteStreamTriggersWhenSocketConnectionRefused()
     {
-        // @link https://github.com/reactphp/event-loop/issues/206
-        if ($this->loop instanceof StreamSelectLoop && DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestIncomplete('StreamSelectLoop does not currently support detecting connection refused errors on Windows');
-        }
-
         // first verify the operating system actually refuses the connection and no firewall is in place
         // use higher timeout because Windows retires multiple times and has a noticeable delay
         // @link https://stackoverflow.com/questions/19440364/why-do-failed-attempts-of-socket-connect-take-1-sec-on-windows
         $errno = $errstr = null;
-        if (@stream_socket_client('127.0.0.1:1', $errno, $errstr, 10.0) !== false || $errno !== SOCKET_ECONNREFUSED) {
+        if (@stream_socket_client('127.0.0.1:1', $errno, $errstr, 10.0) !== false || (defined('SOCKET_ECONNREFUSED') && $errno !== SOCKET_ECONNREFUSED)) {
             $this->markTestSkipped('Expected host to refuse connection, but got error ' . $errno . ': ' . $errstr);
         }
 

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\EventLoop;
 
 use React\EventLoop\StreamSelectLoop;
+use React\EventLoop\ExtUvLoop;
 
 abstract class AbstractLoopTest extends TestCase
 {
@@ -144,6 +145,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddReadStream()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
@@ -157,6 +162,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddReadStreamIgnoresSecondCallable()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableExactly(2));
@@ -206,6 +215,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddWriteStream()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
@@ -215,6 +228,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testAddWriteStreamIgnoresSecondCallable()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableExactly(2));
@@ -225,6 +242,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveReadStreamInstantly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableNever());
@@ -236,6 +257,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveReadStreamAfterReading()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableOnce());
@@ -251,6 +276,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveWriteStreamInstantly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableNever());
@@ -260,6 +289,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveWriteStreamAfterWriting()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input) = $this->createSocketPair();
 
         $this->loop->addWriteStream($input, $this->expectCallableOnce());
@@ -271,6 +304,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveStreamForReadOnly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         $this->loop->addReadStream($input, $this->expectCallableNever());
@@ -283,6 +320,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testRemoveStreamForWriteOnly()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($input, $output) = $this->createSocketPair();
 
         fwrite($output, "foo\n");
@@ -505,6 +546,10 @@ abstract class AbstractLoopTest extends TestCase
 
     public function testFutureTickFiresBeforeIO()
     {
+        if ($this->loop instanceof ExtUvLoop && DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestIncomplete('Ticking ExtUvLoop not supported on Windows');
+        }
+
         list ($stream) = $this->createSocketPair();
 
         $this->loop->addWriteStream(
@@ -525,6 +570,9 @@ abstract class AbstractLoopTest extends TestCase
         $this->tickLoop($this->loop);
     }
 
+    /**
+     * @depends testFutureTickFiresBeforeIO
+     */
     public function testRecursiveFutureTick()
     {
         list ($stream) = $this->createSocketPair();


### PR DESCRIPTION
We do not usually use or expose the `exceptfds` parameter passed to the
underlying `select`. However, Windows does not report failed connection
attempts in `writefds` passed to `select` like most other platforms.
Instead, it uses `writefds` only for successful connection attempts and
`exceptfds` for failed connection attempts. See also
https://docs.microsoft.com/de-de/windows/win32/api/winsock2/nf-winsock2-select

We work around this by adding all sockets that look like a pending
connection attempt to `exceptfds` automatically on Windows and merge it
back later. This ensures the public API matches other loop
implementations across all platforms (see also test suite or rather test
matrix). Lacking better APIs, every write-only socket that has not yet
read any data is assumed to be in a pending connection attempt state.

Resolves #206
Builds on top of #205 and #207 (see last commit to omit unrelated changes)