### PR TITLE
StreamSelectLoop: fix PHP 8 error handling

### DIFF
--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -280,14 +280,22 @@ final class StreamSelectLoop implements LoopInterface
             if (\DIRECTORY_SEPARATOR === '\\') {
                 $except = array();
                 foreach ($write as $key => $socket) {
-                    if (!isset($read[$key]) && @\ftell($socket) === 0) {
-                        $except[$key] = $socket;
+                    try {
+                        if (!isset($read[$key]) && @\ftell($socket) === 0) {
+                            $except[$key] = $socket;
+                        }
+                    } catch (\ErrorException $e) {
+                        // PHP 8 throws exceptions
                     }
                 }
             }
 
             // suppress warnings that occur, when stream_select is interrupted by a signal
-            $ret = @\stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
+            try {
+                $ret = @\stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
+            } catch (\ErrorException $e) {
+                $ret = false;
+            }
 
             if ($except) {
                 $write = \array_merge($write, $except);


### PR DESCRIPTION
When interrupting steam_select() with a signal, StreamSelectLoop throws an
Exception in PHP 8:

    ERROR: ErrorException in event-loop/src/StreamSelectLoop.php:290 with
           message: stream_select(): Unable to select [4]: Interrupted
           system call (max_fd=7)

This fix catches the error and returns false as stream_select used to do. This
fix also catches ftell errors, however I didn't test that part