### PR TITLE
Added php8 into travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
     - php: hhvm-3.18
       dist: trusty
       before_install: [] # skip libuv


### PR DESCRIPTION
As the PHP requirement in composer allows PHP8, would be nice to have this version inside the travis matrix.