### PR TITLE
Global event-loop accessor part four

### DIFF
--- a/examples/01-timers.php
+++ b/examples/01-timers.php
@@ -1,15 +1,15 @@
 <?php
 
+use React\EventLoop\Loop;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
-$loop->addTimer(0.8, function () {
+Loop::get()->addTimer(0.8, function () {
     echo 'world!' . PHP_EOL;
 });
 
-$loop->addTimer(0.3, function () {
+Loop::get()->addTimer(0.3, function () {
     echo 'hello ';
 });
 
-$loop->run();
+Loop::get()->run();

--- a/examples/02-periodic.php
+++ b/examples/02-periodic.php
@@ -1,16 +1,16 @@
 <?php
 
+use React\EventLoop\Loop;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
-$timer = $loop->addPeriodicTimer(0.1, function () {
+$timer = Loop::get()->addPeriodicTimer(0.1, function () {
     echo 'tick!' . PHP_EOL;
 });
 
-$loop->addTimer(1.0, function () use ($loop, $timer) {
-    $loop->cancelTimer($timer);
+Loop::get()->addTimer(1.0, function () use ($timer) {
+    Loop::get()->cancelTimer($timer);
     echo 'Done' . PHP_EOL;
 });
 
-$loop->run();
+Loop::get()->run();

--- a/examples/03-ticks.php
+++ b/examples/03-ticks.php
@@ -1,15 +1,15 @@
 <?php
 
+use React\EventLoop\Loop;
+
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-
-$loop->futureTick(function () {
+Loop::get()->futureTick(function () {
     echo 'b';
 });
-$loop->futureTick(function () {
+Loop::get()->futureTick(function () {
     echo 'c';
 });
 echo 'a';
 
-$loop->run();
+Loop::get()->run();

--- a/examples/04-signals.php
+++ b/examples/04-signals.php
@@ -1,5 +1,7 @@
 <?php
 
+use React\EventLoop\Loop;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 if (!defined('SIGINT')) {
@@ -7,13 +9,11 @@ if (!defined('SIGINT')) {
     exit(1);
 }
 
-$loop = React\EventLoop\Factory::create();
-
-$loop->addSignal(SIGINT, $func = function ($signal) use ($loop, &$func) {
+Loop::get()->addSignal(SIGINT, $func = function ($signal) use (&$func) {
     echo 'Signal: ', (string)$signal, PHP_EOL;
-    $loop->removeSignal(SIGINT, $func);
+    Loop::get()->removeSignal(SIGINT, $func);
 });
 
 echo 'Listening for SIGINT. Use "kill -SIGINT ' . getmypid() . '" or CTRL+C' . PHP_EOL;
 
-$loop->run();
+Loop::get()->run();

--- a/examples/11-consume-stdin.php
+++ b/examples/11-consume-stdin.php
@@ -1,6 +1,6 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -9,16 +9,14 @@ if (!defined('STDIN') || stream_set_blocking(STDIN, false) !== true) {
     exit(1);
 }
 
-$loop = Factory::create();
-
 // read everything from STDIN and report number of bytes
 // for illustration purposes only, should use react/stream instead
-$loop->addReadStream(STDIN, function ($stream) use ($loop) {
+Loop::get()->addReadStream(STDIN, function ($stream) {
     $chunk = fread($stream, 64 * 1024);
 
     // reading nothing means we reached EOF
     if ($chunk === '') {
-        $loop->removeReadStream($stream);
+        Loop::get()->removeReadStream($stream);
         stream_set_blocking($stream, true);
         fclose($stream);
         return;
@@ -27,4 +25,4 @@ $loop->addReadStream(STDIN, function ($stream) use ($loop) {
     echo strlen($chunk) . ' bytes' . PHP_EOL;
 });
 
-$loop->run();
+Loop::get()->run();

--- a/examples/13-http-client-blocking.php
+++ b/examples/13-http-client-blocking.php
@@ -1,10 +1,8 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 // connect to www.google.com:80 (blocking call!)
 // for illustration purposes only, should use react/socket instead
@@ -18,13 +16,13 @@ stream_set_blocking($stream, false);
 fwrite($stream, "GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n");
 
 // wait for HTTP response
-$loop->addReadStream($stream, function ($stream) use ($loop) {
+Loop::get()->addReadStream($stream, function ($stream) {
     $chunk = fread($stream, 64 * 1024);
 
     // reading nothing means we reached EOF
     if ($chunk === '') {
         echo '[END]' . PHP_EOL;
-        $loop->removeReadStream($stream);
+        Loop::get()->removeReadStream($stream);
         fclose($stream);
         return;
     }
@@ -32,4 +30,4 @@ $loop->addReadStream($stream, function ($stream) use ($loop) {
     echo $chunk;
 });
 
-$loop->run();
+Loop::get()->run();

--- a/examples/21-http-server.php
+++ b/examples/21-http-server.php
@@ -1,8 +1,8 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+use React\EventLoop\Loop;
 
-$loop = React\EventLoop\Factory::create();
+require __DIR__ . '/../vendor/autoload.php';
 
 // start TCP/IP server on localhost:8080
 // for illustration purposes only, should use react/socket instead
@@ -13,24 +13,24 @@ if (!$server) {
 stream_set_blocking($server, false);
 
 // wait for incoming connections on server socket
-$loop->addReadStream($server, function ($server) use ($loop) {
+Loop::get()->addReadStream($server, function ($server) {
     $conn = stream_socket_accept($server);
     $data = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nHi\n";
-    $loop->addWriteStream($conn, function ($conn) use (&$data, $loop) {
+    Loop::get()->addWriteStream($conn, function ($conn) use (&$data) {
         $written = fwrite($conn, $data);
         if ($written === strlen($data)) {
             fclose($conn);
-            $loop->removeWriteStream($conn);
+            Loop::get()->removeWriteStream($conn);
         } else {
             $data = substr($data, $written);
         }
     });
 });
 
-$loop->addPeriodicTimer(5, function () {
+Loop::get()->addPeriodicTimer(5, function () {
     $memory = memory_get_usage() / 1024;
     $formatted = number_format($memory, 3).'K';
     echo "Current memory usage: {$formatted}\n";
 });
 
-$loop->run();
+Loop::get()->run();

--- a/examples/91-benchmark-ticks.php
+++ b/examples/91-benchmark-ticks.php
@@ -1,15 +1,13 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 $n = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 
 for ($i = 0; $i < $n; ++$i) {
-    $loop->futureTick(function () { });
+    Loop::get()->futureTick(function () { });
 }
 
-$loop->run();
+Loop::get()->run();

--- a/examples/92-benchmark-timers.php
+++ b/examples/92-benchmark-timers.php
@@ -1,15 +1,13 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 $n = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 
 for ($i = 0; $i < $n; ++$i) {
-    $loop->addTimer(0, function () { });
+    Loop::get()->addTimer(0, function () { });
 }
 
-$loop->run();
+Loop::get()->run();

--- a/examples/93-benchmark-ticks-delay.php
+++ b/examples/93-benchmark-ticks-delay.php
@@ -1,17 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $ticks = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
-$tick = function () use (&$tick, &$ticks, $loop) {
+$tick = function () use (&$tick, &$ticks) {
     if ($ticks > 0) {
         --$ticks;
         //$loop->addTimer(0, $tick);
-        $loop->futureTick($tick);
+        Loop::get()->futureTick($tick);
     } else {
         echo 'done';
     }
@@ -19,4 +17,4 @@ $tick = function () use (&$tick, &$ticks, $loop) {
 
 $tick();
 
-$loop->run();
+Loop::get()->run();

--- a/examples/94-benchmark-timers-delay.php
+++ b/examples/94-benchmark-timers-delay.php
@@ -1,17 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $ticks = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
-$tick = function () use (&$tick, &$ticks, $loop) {
+$tick = function () use (&$tick, &$ticks) {
     if ($ticks > 0) {
         --$ticks;
         //$loop->futureTick($tick);
-        $loop->addTimer(0, $tick);
+        Loop::get()->addTimer(0, $tick);
     } else {
         echo 'done';
     }
@@ -19,4 +17,4 @@ $tick = function () use (&$tick, &$ticks, $loop) {
 
 $tick();
 
-$loop->run();
+Loop::get()->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -19,21 +19,44 @@ final class Factory
      *
      * This method should usually only be called once at the beginning of the program.
      *
+     * @deprecated Use Loop::get instead
+     *
      * @return LoopInterface
      */
     public static function create()
+    {
+        $loop = self::construct();
+
+        Loop::set($loop);
+
+        return $loop;
+    }
+
+    /**
+     * @internal
+     * @return LoopInterface
+     */
+    private static function construct()
     {
         // @codeCoverageIgnoreStart
         if (\function_exists('uv_loop_new')) {
             // only use ext-uv on PHP 7
             return new ExtUvLoop();
-        } elseif (\class_exists('libev\EventLoop', false)) {
+        }
+
+        if (\class_exists('libev\EventLoop', false)) {
             return new ExtLibevLoop();
-        } elseif (\class_exists('EvLoop', false)) {
+        }
+
+        if (\class_exists('EvLoop', false)) {
             return new ExtEvLoop();
-        } elseif (\class_exists('EventBase', false)) {
+        }
+
+        if (\class_exists('EventBase', false)) {
             return new ExtEventLoop();
-        } elseif (\function_exists('event_base_new') && \PHP_MAJOR_VERSION === 5) {
+        }
+
+        if (\function_exists('event_base_new') && \PHP_MAJOR_VERSION === 5) {
             // only use ext-libevent on PHP 5 for now
             return new ExtLibeventLoop();
         }

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace React\EventLoop;
+
+/**
+ * The `Loop` class exists as a convenient way to get the currently relevant loop
+ */
+final class Loop
+{
+    /**
+     * @var LoopInterface
+     */
+    private static $instance;
+
+
+    /**
+     * Returns the event loop.
+     * When no loop is set it will it will call the factory to create one.
+     *
+     * This method always returns an instance implementing `LoopInterface`,
+     * the actual event loop implementation is an implementation detail.
+     *
+     * This method is the preferred way to get the event loop and using
+     * Factory::create has been deprecated.
+     *
+     * @return LoopInterface
+     */
+    public static function get()
+    {
+        if (self::$instance instanceof LoopInterface) {
+            return self::$instance;
+        }
+
+        self::$instance = Factory::create();
+
+        return self::$instance;
+    }
+
+    /**
+     * Internal undocumented method, behavior might change or throw in the
+     * future. Use with cation and at your own risk.
+     *
+     * @internal
+     * @return void
+     */
+    public static function set(LoopInterface $loop)
+    {
+        self::$instance = $loop;
+    }
+}

--- a/tests/LoopTest.php
+++ b/tests/LoopTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace React\Tests\EventLoop;
+
+use React\EventLoop\Factory;
+use React\EventLoop\Loop;
+use ReflectionClass;
+
+final class LoopTest extends TestCase
+{
+    /**
+     * @dataProvider numberOfTests
+     */
+    public function testFactoryCreateSetsEventLoopOnLoopAccessor()
+    {
+        $factoryLoop = Factory::create();
+        $accessorLoop = Loop::get();
+
+        self::assertSame($factoryLoop, $accessorLoop);
+    }
+
+    /**
+     * @dataProvider numberOfTests
+     */
+    public function testCallingFactoryAfterCallingLoopGetYieldsADifferentInstanceOfTheEventLoop()
+    {
+        // Note that this behavior isn't wise and highly advised against. Always used Loop::get.
+        $accessorLoop = Loop::get();
+        $factoryLoop = Factory::create();
+
+        self::assertNotSame($factoryLoop, $accessorLoop);
+    }
+
+    /**
+     * @dataProvider numberOfTests
+     */
+    public function testCallingLoopGetShouldAlwaysReturnTheSameEventLoop()
+    {
+        self::assertSame(Loop::get(), Loop::get());
+    }
+
+    /**
+     * Run several tests several times to ensure we reset the loop between tests and code is still behavior as expected.
+     *
+     * @return array<array>
+     */
+    public function numberOfTests()
+    {
+        return array(array(), array(), array());
+    }
+
+    /**
+     * @after
+     * @before
+     */
+    public function unsetLoopFromLoopAccessor()
+    {
+        $ref = new ReflectionClass('\React\EventLoop\Loop');
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+        $prop->setAccessible(false);
+    }
+}


### PR DESCRIPTION
This topic has come up before in #10, #77, and #82. And their aim was to provide all the pieces in one go, the aim for this PR, and its successors in line, is to discuss all bits in their own PR. As such this PR is providing the bare minimum.

To help that I've made several examples to provide different angles on this topic:
* Full switch over to the new global loop accessor: https://github.com/WyriHaximus/reactphp-cron/pull/51
* Make passing the loop optional, but as the recommended way: https://github.com/clue/reactphp-redis/pull/110
* Fully switch over to the global loop accessor, including setting a new loop for each test: https://github.com/clue/reactphp-redis/pull/109



Resolves: #10 #77 #82