### PR TITLE
Add static Loop methods

### DIFF
--- a/examples/01-timers.php
+++ b/examples/01-timers.php
@@ -4,12 +4,12 @@ use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-Loop::get()->addTimer(0.8, function () {
+Loop::addTimer(0.8, function () {
     echo 'world!' . PHP_EOL;
 });
 
-Loop::get()->addTimer(0.3, function () {
+Loop::addTimer(0.3, function () {
     echo 'hello ';
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/02-periodic.php
+++ b/examples/02-periodic.php
@@ -4,13 +4,13 @@ use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$timer = Loop::get()->addPeriodicTimer(0.1, function () {
+$timer = Loop::addPeriodicTimer(0.1, function () {
     echo 'tick!' . PHP_EOL;
 });
 
-Loop::get()->addTimer(1.0, function () use ($timer) {
-    Loop::get()->cancelTimer($timer);
+Loop::addTimer(1.0, function () use ($timer) {
+    Loop::cancelTimer($timer);
     echo 'Done' . PHP_EOL;
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/03-ticks.php
+++ b/examples/03-ticks.php
@@ -4,12 +4,12 @@ use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-Loop::get()->futureTick(function () {
+Loop::futureTick(function () {
     echo 'b';
 });
-Loop::get()->futureTick(function () {
+Loop::futureTick(function () {
     echo 'c';
 });
 echo 'a';
 
-Loop::get()->run();
+Loop::run();

--- a/examples/04-signals.php
+++ b/examples/04-signals.php
@@ -9,11 +9,11 @@ if (!defined('SIGINT')) {
     exit(1);
 }
 
-Loop::get()->addSignal(SIGINT, $func = function ($signal) use (&$func) {
+Loop::addSignal(SIGINT, $func = function ($signal) use (&$func) {
     echo 'Signal: ', (string)$signal, PHP_EOL;
-    Loop::get()->removeSignal(SIGINT, $func);
+    Loop::removeSignal(SIGINT, $func);
 });
 
 echo 'Listening for SIGINT. Use "kill -SIGINT ' . getmypid() . '" or CTRL+C' . PHP_EOL;
 
-Loop::get()->run();
+Loop::run();

--- a/examples/11-consume-stdin.php
+++ b/examples/11-consume-stdin.php
@@ -11,12 +11,12 @@ if (!defined('STDIN') || stream_set_blocking(STDIN, false) !== true) {
 
 // read everything from STDIN and report number of bytes
 // for illustration purposes only, should use react/stream instead
-Loop::get()->addReadStream(STDIN, function ($stream) {
+Loop::addReadStream(STDIN, function ($stream) {
     $chunk = fread($stream, 64 * 1024);
 
     // reading nothing means we reached EOF
     if ($chunk === '') {
-        Loop::get()->removeReadStream($stream);
+        Loop::removeReadStream($stream);
         stream_set_blocking($stream, true);
         fclose($stream);
         return;
@@ -25,4 +25,4 @@ Loop::get()->addReadStream(STDIN, function ($stream) {
     echo strlen($chunk) . ' bytes' . PHP_EOL;
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/12-generate-yes.php
+++ b/examples/12-generate-yes.php
@@ -17,13 +17,13 @@ if (!defined('STDOUT') || stream_set_blocking(STDOUT, false) !== true) {
 
 // write data to STDOUT whenever its write buffer accepts data
 // for illustrations purpose only, should use react/stream instead
-Loop::get()->addWriteStream(STDOUT, function ($stdout) use (&$data) {
+Loop::addWriteStream(STDOUT, function ($stdout) use (&$data) {
     // try to write data
     $r = fwrite($stdout, $data);
 
     // nothing could be written despite being writable => closed
     if ($r === 0) {
-        Loop::get()->removeWriteStream($stdout);
+        Loop::removeWriteStream($stdout);
         fclose($stdout);
         stream_set_blocking($stdout, true);
         fwrite(STDERR, 'Stopped because STDOUT closed' . PHP_EOL);
@@ -38,4 +38,4 @@ Loop::get()->addWriteStream(STDOUT, function ($stdout) use (&$data) {
     }
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/13-http-client-blocking.php
+++ b/examples/13-http-client-blocking.php
@@ -16,13 +16,13 @@ stream_set_blocking($stream, false);
 fwrite($stream, "GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n");
 
 // wait for HTTP response
-Loop::get()->addReadStream($stream, function ($stream) {
+Loop::addReadStream($stream, function ($stream) {
     $chunk = fread($stream, 64 * 1024);
 
     // reading nothing means we reached EOF
     if ($chunk === '') {
         echo '[END]' . PHP_EOL;
-        Loop::get()->removeReadStream($stream);
+        Loop::removeReadStream($stream);
         fclose($stream);
         return;
     }
@@ -30,4 +30,4 @@ Loop::get()->addReadStream($stream, function ($stream) {
     echo $chunk;
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/14-http-client-async.php
+++ b/examples/14-http-client-async.php
@@ -23,14 +23,14 @@ stream_set_blocking($stream, false);
 
 // print progress every 10ms
 echo 'Connecting';
-$timer = Loop::get()->addPeriodicTimer(0.01, function () {
+$timer = Loop::addPeriodicTimer(0.01, function () {
     echo '.';
 });
 
 // wait for connection success/error
-Loop::get()->addWriteStream($stream, function ($stream) use ($timer) {
-    Loop::get()->removeWriteStream($stream);
-    Loop::get()->cancelTimer($timer);
+Loop::addWriteStream($stream, function ($stream) use ($timer) {
+    Loop::removeWriteStream($stream);
+    Loop::cancelTimer($timer);
 
     // check for socket error (connection rejected)
     if (stream_socket_get_name($stream, true) === false) {
@@ -44,13 +44,13 @@ Loop::get()->addWriteStream($stream, function ($stream) use ($timer) {
     fwrite($stream, "GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n");
 
     // wait for HTTP response
-    Loop::get()->addReadStream($stream, function ($stream) {
+    Loop::addReadStream($stream, function ($stream) {
         $chunk = fread($stream, 64 * 1024);
 
         // reading nothing means we reached EOF
         if ($chunk === '') {
             echo '[END]' . PHP_EOL;
-            Loop::get()->removeReadStream($stream);
+            Loop::removeReadStream($stream);
             fclose($stream);
             return;
         }
@@ -59,4 +59,4 @@ Loop::get()->addWriteStream($stream, function ($stream) use ($timer) {
     });
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/21-http-server.php
+++ b/examples/21-http-server.php
@@ -13,24 +13,24 @@ if (!$server) {
 stream_set_blocking($server, false);
 
 // wait for incoming connections on server socket
-Loop::get()->addReadStream($server, function ($server) {
+Loop::addReadStream($server, function ($server) {
     $conn = stream_socket_accept($server);
     $data = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nHi\n";
-    Loop::get()->addWriteStream($conn, function ($conn) use (&$data) {
+    Loop::addWriteStream($conn, function ($conn) use (&$data) {
         $written = fwrite($conn, $data);
         if ($written === strlen($data)) {
             fclose($conn);
-            Loop::get()->removeWriteStream($conn);
+            Loop::removeWriteStream($conn);
         } else {
             $data = substr($data, $written);
         }
     });
 });
 
-Loop::get()->addPeriodicTimer(5, function () {
+Loop::addPeriodicTimer(5, function () {
     $memory = memory_get_usage() / 1024;
     $formatted = number_format($memory, 3).'K';
     echo "Current memory usage: {$formatted}\n";
 });
 
-Loop::get()->run();
+Loop::run();

--- a/examples/91-benchmark-ticks.php
+++ b/examples/91-benchmark-ticks.php
@@ -7,7 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $n = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 
 for ($i = 0; $i < $n; ++$i) {
-    Loop::get()->futureTick(function () { });
+    Loop::futureTick(function () { });
 }
 
-Loop::get()->run();
+Loop::run();

--- a/examples/92-benchmark-timers.php
+++ b/examples/92-benchmark-timers.php
@@ -7,7 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $n = isset($argv[1]) ? (int)$argv[1] : 1000 * 100;
 
 for ($i = 0; $i < $n; ++$i) {
-    Loop::get()->addTimer(0, function () { });
+    Loop::addTimer(0, function () { });
 }
 
-Loop::get()->run();
+Loop::run();

--- a/examples/93-benchmark-ticks-delay.php
+++ b/examples/93-benchmark-ticks-delay.php
@@ -9,7 +9,7 @@ $tick = function () use (&$tick, &$ticks) {
     if ($ticks > 0) {
         --$ticks;
         //$loop->addTimer(0, $tick);
-        Loop::get()->futureTick($tick);
+        Loop::futureTick($tick);
     } else {
         echo 'done';
     }
@@ -17,4 +17,4 @@ $tick = function () use (&$tick, &$ticks) {
 
 $tick();
 
-Loop::get()->run();
+Loop::run();

--- a/examples/94-benchmark-timers-delay.php
+++ b/examples/94-benchmark-timers-delay.php
@@ -9,7 +9,7 @@ $tick = function () use (&$tick, &$ticks) {
     if ($ticks > 0) {
         --$ticks;
         //$loop->futureTick($tick);
-        Loop::get()->addTimer(0, $tick);
+        Loop::addTimer(0, $tick);
     } else {
         echo 'done';
     }
@@ -17,4 +17,4 @@ $tick = function () use (&$tick, &$ticks) {
 
 $tick();
 
-Loop::get()->run();
+Loop::run();

--- a/examples/95-benchmark-memory.php
+++ b/examples/95-benchmark-memory.php
@@ -7,7 +7,6 @@
  * php 95-benchmark-memory.php -t 30 -l StreamSelect -r 10
  */
 
-use React\EventLoop\Factory;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
@@ -27,21 +26,21 @@ $r = isset($args['r']) ? (int)$args['r'] : 2;
 $runs = 0;
 
 if (5 < $t) {
-    Loop::get()->addTimer($t, function () {
-        Loop::get()->stop();
+    Loop::addTimer($t, function () {
+        Loop::stop();
     });
 
 }
 
-Loop::get()->addPeriodicTimer(0.001, function () use (&$runs) {
+Loop::addPeriodicTimer(0.001, function () use (&$runs) {
     $runs++;
 
-    Loop::get()->addPeriodicTimer(1, function (TimerInterface $timer) {
-        Loop::get()->cancelTimer($timer);
+    Loop::addPeriodicTimer(1, function (TimerInterface $timer) {
+        Loop::cancelTimer($timer);
     });
 });
 
-Loop::get()->addPeriodicTimer($r, function () use (&$runs) {
+Loop::addPeriodicTimer($r, function () use (&$runs) {
     $kmem = round(memory_get_usage() / 1024);
     $kmemReal = round(memory_get_usage(true) / 1024);
     echo "Runs:\t\t\t$runs\n";
@@ -57,7 +56,7 @@ echo "Time\t\t\t", date('r'), "\n";
 echo str_repeat('-', 50), "\n";
 
 $beginTime = time();
-Loop::get()->run();
+Loop::run();
 $endTime = time();
 $timeTaken = $endTime - $beginTime;
 

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -47,4 +47,154 @@ final class Loop
     {
         self::$instance = $loop;
     }
+
+    /**
+     * [Advanced] Register a listener to be notified when a stream is ready to read.
+     *
+     * @param resource $stream
+     * @param callable $listener
+     * @return void
+     * @throws \Exception
+     * @see LoopInterface::addReadStream()
+     */
+    public static function addReadStream($stream, $listener)
+    {
+        self::get()->addReadStream($stream, $listener);
+    }
+
+    /**
+     * [Advanced] Register a listener to be notified when a stream is ready to write.
+     *
+     * @param resource $stream
+     * @param callable $listener
+     * @return void
+     * @throws \Exception
+     * @see LoopInterface::addWriteStream()
+     */
+    public static function addWriteStream($stream, $listener)
+    {
+        self::get()->addWriteStream($stream, $listener);
+    }
+
+    /**
+     * Remove the read event listener for the given stream.
+     *
+     * @param resource $stream
+     * @return void
+     * @see LoopInterface::removeReadStream()
+     */
+    public static function removeReadStream($stream)
+    {
+        self::get()->removeReadStream($stream);
+    }
+
+    /**
+     * Remove the write event listener for the given stream.
+     *
+     * @param resource $stream
+     * @return void
+     * @see LoopInterface::removeWriteStream()
+     */
+    public static function removeWriteStream($stream)
+    {
+        self::get()->removeWriteStream($stream);
+    }
+
+    /**
+     * Enqueue a callback to be invoked once after the given interval.
+     *
+     * @param float $interval
+     * @param callable $callback
+     * @return TimerInterface
+     * @see LoopInterface::addTimer()
+     */
+    public static function addTimer($interval, $callback)
+    {
+        return self::get()->addTimer($interval, $callback);
+    }
+
+    /**
+     * Enqueue a callback to be invoked repeatedly after the given interval.
+     *
+     * @param float $interval
+     * @param callable $callback
+     * @return TimerInterface
+     * @see LoopInterface::addPeriodicTimer()
+     */
+    public static function addPeriodicTimer($interval, $callback)
+    {
+        return self::get()->addPeriodicTimer($interval, $callback);
+    }
+
+    /**
+     * Cancel a pending timer.
+     *
+     * @param TimerInterface $timer
+     * @return void
+     * @see LoopInterface::cancelTimer()
+     */
+    public static function cancelTimer(TimerInterface $timer)
+    {
+        return self::get()->cancelTimer($timer);
+    }
+
+    /**
+     * Schedule a callback to be invoked on a future tick of the event loop.
+     *
+     * @param callable $listener
+     * @return void
+     * @see LoopInterface::futureTick()
+     */
+    public static function futureTick($listener)
+    {
+        self::get()->futureTick($listener);
+    }
+
+    /**
+     * Register a listener to be notified when a signal has been caught by this process.
+     *
+     * @param int $signal
+     * @param callable $listener
+     * @return void
+     * @see LoopInterface::addSignal()
+     */
+    public static function addSignal($signal, $listener)
+    {
+        self::get()->addSignal($signal, $listener);
+    }
+
+    /**
+     * Removes a previously added signal listener.
+     *
+     * @param int $signal
+     * @param callable $listener
+     * @return void
+     * @see LoopInterface::removeSignal()
+     */
+    public static function removeSignal($signal, $listener)
+    {
+        self::get()->removeSignal($signal, $listener);
+    }
+
+    /**
+     * Run the event loop until there are no more tasks to perform.
+     *
+     * @return void
+     * @see LoopInterface::run()
+     */
+    public static function run()
+    {
+        self::get()->run();
+    }
+
+    /**
+     * Instruct a running event loop to stop.
+     *
+     * @return void
+     * @see LoopInterface::stop()
+     */
+    public static function stop()
+    {
+        self::get()->stop();
+    }
 }

--- a/tests/LoopTest.php
+++ b/tests/LoopTest.php
@@ -49,6 +49,158 @@ final class LoopTest extends TestCase
         return array(array(), array(), array());
     }
 
+    public function testStaticAddReadStreamCallsAddReadStreamOnLoopInstance()
+    {
+        $stream = tmpfile();
+        $listener = function () { };
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream, $listener);
+
+        Loop::set($loop);
+
+        Loop::addReadStream($stream, $listener);
+    }
+
+    public function testStaticAddWriteStreamCallsAddWriteStreamOnLoopInstance()
+    {
+        $stream = tmpfile();
+        $listener = function () { };
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addWriteStream')->with($stream, $listener);
+
+        Loop::set($loop);
+
+        Loop::addWriteStream($stream, $listener);
+    }
+
+    public function testStaticRemoveReadStreamCallsRemoveReadStreamOnLoopInstance()
+    {
+        $stream = tmpfile();
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        Loop::set($loop);
+
+        Loop::removeReadStream($stream);
+    }
+
+    public function testStaticRemoveWriteStreamCallsRemoveWriteStreamOnLoopInstance()
+    {
+        $stream = tmpfile();
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeWriteStream')->with($stream);
+
+        Loop::set($loop);
+
+        Loop::removeWriteStream($stream);
+    }
+
+    public function testStaticAddTimerCallsAddTimerOnLoopInstanceAndReturnsTimerInstance()
+    {
+        $interval = 1.0;
+        $callback = function () { };
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with($interval, $callback)->willReturn($timer);
+
+        Loop::set($loop);
+
+        $ret = Loop::addTimer($interval, $callback);
+
+        $this->assertSame($timer, $ret);
+    }
+
+    public function testStaticAddPeriodicTimerCallsAddPeriodicTimerOnLoopInstanceAndReturnsTimerInstance()
+    {
+        $interval = 1.0;
+        $callback = function () { };
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addPeriodicTimer')->with($interval, $callback)->willReturn($timer);
+
+        Loop::set($loop);
+
+        $ret = Loop::addPeriodicTimer($interval, $callback);
+
+        $this->assertSame($timer, $ret);
+    }
+
+    public function testStaticCancelTimerCallsCancelTimerOnLoopInstance()
+    {
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        Loop::set($loop);
+
+        Loop::cancelTimer($timer);
+    }
+
+    public function testStaticFutureTickCallsFutureTickOnLoopInstance()
+    {
+        $listener = function () { };
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('futureTick')->with($listener);
+
+        Loop::set($loop);
+
+        Loop::futureTick($listener);
+    }
+
+    public function testStaticAddSignalCallsAddSignalOnLoopInstance()
+    {
+        $signal = 1;
+        $listener = function () { };
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addSignal')->with($signal, $listener);
+
+        Loop::set($loop);
+
+        Loop::addSignal($signal, $listener);
+    }
+
+    public function testStaticRemoveSignalCallsRemoveSignalOnLoopInstance()
+    {
+        $signal = 1;
+        $listener = function () { };
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('removeSignal')->with($signal, $listener);
+
+        Loop::set($loop);
+
+        Loop::removeSignal($signal, $listener);
+    }
+
+    public function testStaticRunCallsRunOnLoopInstance()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('run')->with();
+
+        Loop::set($loop);
+
+        Loop::run();
+    }
+
+    public function testStaticStopCallsStopOnLoopInstance()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('stop')->with();
+
+        Loop::set($loop);
+
+        Loop::stop();
+    }
+
     /**
      * @after
      * @before


### PR DESCRIPTION
This changeset adds static Loop methods. The Loop class now provides all methods that exist on the LoopInterface as static methods:

```php
use React\EventLoop\Loop;

// old (still supported)
Loop::get()->addTimer(1.0, fn () => echo 'Tick');
Loop::get()->run();

// new
Loop::addTimer(1.0, fn () => echo 'Tick');
Loop::run();
```

This is particularly useful when directly interfacing with the event loop in application code. I've also updated the documentation to highlight some use cases where the `Loop::get()` method would still be useful when using dependency injection (DI).

Builds on top of #226 