### PR TITLE
Mark legacy extensions as deprecated and minor documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ single [`run()`](#run) call that is controlled by the user.
     * [Loop implementations](#loop-implementations)
         * [StreamSelectLoop](#streamselectloop)
         * [ExtEventLoop](#exteventloop)
-        * [ExtLibeventLoop](#extlibeventloop)
-        * [ExtLibevLoop](#extlibevloop)
+        * [~~ExtLibeventLoop~~](#extlibeventloop)
+        * [~~ExtLibevLoop~~](#extlibevloop)
         * [ExtEvLoop](#extevloop)
         * [ExtUvLoop](#extuvloop)
     * [LoopInterface](#loopinterface)
@@ -362,8 +362,9 @@ See also [`addTimer()`](#addtimer) for more details.
 
 An `ext-event` based event loop.
 
-This uses the [`event` PECL extension](https://pecl.php.net/package/event).
-It supports the same backends as libevent.
+This uses the [`event` PECL extension](https://pecl.php.net/package/event),
+that provides an interface to `libevent` library.
+`libevent` itself supports a number of system-specific backends (epoll, kqueue).
 
 This loop is known to work with PHP 5.4 through PHP 7+.
 
@@ -371,8 +372,10 @@ This loop is known to work with PHP 5.4 through PHP 7+.
 
 An `ext-ev` based event loop.
 
-This loop uses the [`ev` PECL extension](https://pecl.php.net/package/ev), that
-provides an interface to `libev` library.
+This loop uses the [`ev` PECL extension](https://pecl.php.net/package/ev),
+that provides an interface to `libev` library.
+`libev` itself supports a number of system-specific backends (epoll, kqueue).
+
 
 This loop is known to work with PHP 5.4 through PHP 7+.
 
@@ -380,16 +383,20 @@ This loop is known to work with PHP 5.4 through PHP 7+.
 
 An `ext-uv` based event loop.
 
-This loop uses the [`uv` PECL extension](https://pecl.php.net/package/uv), that
-provides an interface to `libuv` library.
+This loop uses the [`uv` PECL extension](https://pecl.php.net/package/uv),
+that provides an interface to `libuv` library.
+`libuv` itself supports a number of system-specific backends (epoll, kqueue).
 
 This loop is known to work with PHP 7+.
 
-#### ExtLibeventLoop
+#### ~~ExtLibeventLoop~~
+
+> Deprecated since v1.2.0, use [`ExtEventLoop`](#exteventloop) instead.
 
 An `ext-libevent` based event loop.
 
-This uses the [`libevent` PECL extension](https://pecl.php.net/package/libevent).
+This uses the [`libevent` PECL extension](https://pecl.php.net/package/libevent),
+that provides an interface to `libevent` library.
 `libevent` itself supports a number of system-specific backends (epoll, kqueue).
 
 This event loop does only work with PHP 5.
@@ -408,12 +415,15 @@ As such, it's recommended to use `stream_set_read_buffer($stream, 0);`
 to disable PHP's internal read buffer in this case.
 See also [`addReadStream()`](#addreadstream) for more details.
 
-#### ExtLibevLoop
+#### ~~ExtLibevLoop~~
+
+> Deprecated since v1.2.0, use [`ExtEvLoop`](#extevloop) instead.
 
 An `ext-libev` based event loop.
 
-This uses an [unofficial `libev` extension](https://github.com/m4rw3r/php-libev).
-It supports the same backends as libevent.
+This uses an [unofficial `libev` extension](https://github.com/m4rw3r/php-libev),
+that provides an interface to `libev` library.
+`libev` itself supports a number of system-specific backends (epoll, kqueue).
 
 This loop does only work with PHP 5.
 An update for PHP 7 is [unlikely](https://github.com/m4rw3r/php-libev/issues/8)

--- a/src/ExtEvLoop.php
+++ b/src/ExtEvLoop.php
@@ -14,6 +14,7 @@ use SplObjectStorage;
  *
  * This loop uses the [`ev` PECL extension](https://pecl.php.net/package/ev),
  * that provides an interface to `libev` library.
+ * `libev` itself supports a number of system-specific backends (epoll, kqueue).
  *
  * This loop is known to work with PHP 5.4 through PHP 7+.
  *

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -12,8 +12,9 @@ use SplObjectStorage;
 /**
  * An `ext-event` based event loop.
  *
- * This uses the [`event` PECL extension](https://pecl.php.net/package/event).
- * It supports the same backends as libevent.
+ * This uses the [`event` PECL extension](https://pecl.php.net/package/event),
+ * that provides an interface to `libevent` library.
+ * `libevent` itself supports a number of system-specific backends (epoll, kqueue).
  *
  * This loop is known to work with PHP 5.4 through PHP 7+.
  *

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -12,10 +12,11 @@ use React\EventLoop\Timer\Timer;
 use SplObjectStorage;
 
 /**
- * An `ext-libev` based event loop.
+ * [Deprecated] An `ext-libev` based event loop.
  *
- * This uses an [unofficial `libev` extension](https://github.com/m4rw3r/php-libev).
- * It supports the same backends as libevent.
+ * This uses an [unofficial `libev` extension](https://github.com/m4rw3r/php-libev),
+ * that provides an interface to `libev` library.
+ * `libev` itself supports a number of system-specific backends (epoll, kqueue).
  *
  * This loop does only work with PHP 5.
  * An update for PHP 7 is [unlikely](https://github.com/m4rw3r/php-libev/issues/8)
@@ -23,6 +24,7 @@ use SplObjectStorage;
  *
  * @see https://github.com/m4rw3r/php-libev
  * @see https://gist.github.com/1688204
+ * @deprecated 1.2.0, use [`ExtEvLoop`](#extevloop) instead.
  */
 final class ExtLibevLoop implements LoopInterface
 {

--- a/src/ExtLibeventLoop.php
+++ b/src/ExtLibeventLoop.php
@@ -10,9 +10,10 @@ use React\EventLoop\Timer\Timer;
 use SplObjectStorage;
 
 /**
- * An `ext-libevent` based event loop.
+ * [Deprecated] An `ext-libevent` based event loop.
  *
- * This uses the [`libevent` PECL extension](https://pecl.php.net/package/libevent).
+ * This uses the [`libevent` PECL extension](https://pecl.php.net/package/libevent),
+ * that provides an interface to `libevent` library.
  * `libevent` itself supports a number of system-specific backends (epoll, kqueue).
  *
  * This event loop does only work with PHP 5.
@@ -32,6 +33,7 @@ use SplObjectStorage;
  * See also [`addReadStream()`](#addreadstream) for more details.
  *
  * @link https://pecl.php.net/package/libevent
+ * @deprecated 1.2.0, use [`ExtEventLoop`](#exteventloop) instead.
  */
 final class ExtLibeventLoop implements LoopInterface
 {

--- a/src/ExtUvLoop.php
+++ b/src/ExtUvLoop.php
@@ -11,6 +11,7 @@ use SplObjectStorage;
  *
  * This loop uses the [`uv` PECL extension](https://pecl.php.net/package/uv),
  * that provides an interface to `libuv` library.
+ * `libuv` itself supports a number of system-specific backends (epoll, kqueue).
  *
  * This loop is known to work with PHP 7+.
  *


### PR DESCRIPTION
The maintenance for `ExtLibeventLoop` and `ExtLibevLoop` hasn't seen an update since 2013. It's time to move on.