### PR TITLE
Improve test suite to declare and validate helper variables and support running from meta repository (PHP 8.1)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React test suite">
             <directory>./tests/</directory>

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -12,7 +12,11 @@ abstract class AbstractLoopTest extends TestCase
      */
     protected $loop;
 
+    /** @var float */
     private $tickTimeout;
+
+    /** @var ?string */
+    private $received;
 
     const PHP_DEFAULT_CHUNK_SIZE = 8192;
 

--- a/tests/ExtEventLoopTest.php
+++ b/tests/ExtEventLoopTest.php
@@ -6,6 +6,9 @@ use React\EventLoop\ExtEventLoop;
 
 class ExtEventLoopTest extends AbstractLoopTest
 {
+    /** @var ?string */
+    private $fifoPath;
+
     public function createLoop($readStreamCompatible = false)
     {
         if ('Linux' === PHP_OS && !extension_loaded('posix')) {
@@ -19,12 +22,23 @@ class ExtEventLoopTest extends AbstractLoopTest
         return new ExtEventLoop();
     }
 
+    /**
+     * @after
+     */
+    public function tearDownFile()
+    {
+        if ($this->fifoPath !== null && file_exists($this->fifoPath)) {
+            unlink($this->fifoPath);
+        }
+    }
+
     public function createStream()
     {
         // Use a FIFO on linux to get around lack of support for disk-based file
         // descriptors when using the EPOLL back-end.
         if ('Linux' === PHP_OS) {
             $this->fifoPath = tempnam(sys_get_temp_dir(), 'react-');
+            assert(is_string($this->fifoPath));
 
             unlink($this->fifoPath);
 

--- a/tests/ExtLibeventLoopTest.php
+++ b/tests/ExtLibeventLoopTest.php
@@ -6,6 +6,7 @@ use React\EventLoop\ExtLibeventLoop;
 
 class ExtLibeventLoopTest extends AbstractLoopTest
 {
+    /** @var ?string */
     private $fifoPath;
 
     public function createLoop()
@@ -26,7 +27,7 @@ class ExtLibeventLoopTest extends AbstractLoopTest
      */
     public function tearDownFile()
     {
-        if (file_exists($this->fifoPath)) {
+        if ($this->fifoPath !== null && file_exists($this->fifoPath)) {
             unlink($this->fifoPath);
         }
     }
@@ -38,6 +39,7 @@ class ExtLibeventLoopTest extends AbstractLoopTest
         }
 
         $this->fifoPath = tempnam(sys_get_temp_dir(), 'react-');
+        assert(is_string($this->fifoPath));
 
         unlink($this->fifoPath);
 

--- a/tests/bin/01-ticks-loop-class.php
+++ b/tests/bin/01-ticks-loop-class.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 Loop::futureTick(function () {
     echo 'b';

--- a/tests/bin/02-ticks-loop-instance.php
+++ b/tests/bin/02-ticks-loop-instance.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 $loop = Loop::get();
 

--- a/tests/bin/03-ticks-loop-stop.php
+++ b/tests/bin/03-ticks-loop-stop.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 $loop = Loop::get();
 

--- a/tests/bin/11-uncaught.php
+++ b/tests/bin/11-uncaught.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 Loop::addTimer(10.0, function () {
     echo 'never';

--- a/tests/bin/12-undefined.php
+++ b/tests/bin/12-undefined.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 Loop::get()->addTimer(10.0, function () {
     echo 'never';

--- a/tests/bin/21-stop.php
+++ b/tests/bin/21-stop.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 Loop::addTimer(10.0, function () {
     echo 'never';

--- a/tests/bin/22-stop-uncaught.php
+++ b/tests/bin/22-stop-uncaught.php
@@ -2,7 +2,8 @@
 
 use React\EventLoop\Loop;
 
-require __DIR__ . '/../../vendor/autoload.php';
+// autoload for local project development or project installed as dependency for reactphp/reactphp
+(@include __DIR__ . '/../../vendor/autoload.php') || require __DIR__ . '/../../../../autoload.php';
 
 Loop::addTimer(10.0, function () {
     echo 'never';


### PR DESCRIPTION
This changeset updates the test suite to declare and validate helper variables (for future PHP 8.2+ compatibility and because these variables may report an `E_DEPRECATED` in tests for PHP 8.1+). This only affects the test suite and is a bit harder to reproduce in this repository itself, but I've stumbled over this while updating ReactPHP's combined test suite that runs all tests of all components and happens to report said `E_DEPRECATED` on PHP 8.1+.

I'll link the downstream PR against this one, a failed test run reported a bunch of these messages:

```
Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /data/vendor/react/event-loop/tests/ExtLibeventLoopTest.php on line 29
```

Builds on top of #238, #232 and https://github.com/reactphp/reactphp/pull/445
Refs https://github.com/reactphp/http/pull/440 for a similar test update
Refs https://github.com/reactphp/dns/pull/186 for a similar PHP 8.2+ changeset