### PR TITLE
Fix periodic timer with zero interval for `ExtEvLoop` and legacy `ExtLibevLoop`

### DIFF
--- a/src/ExtEvLoop.php
+++ b/src/ExtEvLoop.php
@@ -162,7 +162,7 @@ class ExtEvLoop implements LoopInterface
             \call_user_func($timer->getCallback(), $timer);
         };
 
-        $event = $this->loop->timer($interval, $interval, $callback);
+        $event = $this->loop->timer($timer->getInterval(), $timer->getInterval(), $callback);
         $this->timers->attach($timer, $event);
 
         return $timer;

--- a/src/ExtLibevLoop.php
+++ b/src/ExtLibevLoop.php
@@ -132,7 +132,7 @@ final class ExtLibevLoop implements LoopInterface
             \call_user_func($timer->getCallback(), $timer);
         };
 
-        $event = new TimerEvent($callback, $interval, $interval);
+        $event = new TimerEvent($callback, $timer->getInterval(), $timer->getInterval());
         $this->timerEvents->attach($timer, $event);
         $this->loop->add($event);
 

--- a/tests/Timer/AbstractTimerTest.php
+++ b/tests/Timer/AbstractTimerTest.php
@@ -121,6 +121,26 @@ abstract class AbstractTimerTest extends TestCase
         $this->assertEquals(0.000001, $timer->getInterval());
     }
 
+    public function testAddPeriodicTimerWithZeroIntervalWillExecuteCallbackFunctionAtLeastTwice()
+    {
+        $loop = $this->createLoop();
+
+        $timeout = $loop->addTimer(2, $this->expectCallableNever()); //Timeout the test after two seconds if the periodic timer hasn't fired twice
+
+        $i = 0;
+        $loop->addPeriodicTimer(0, function ($timer) use (&$i, $loop, $timeout) {
+            ++$i;
+            if ($i === 2) {
+                $loop->cancelTimer($timer);
+                $loop->cancelTimer($timeout);
+            }
+        });
+
+        $loop->run();
+
+        $this->assertEquals(2, $i);
+    }
+
     public function testTimerIntervalBelowZeroRunsImmediately()
     {
         $loop = $this->createLoop();


### PR DESCRIPTION
When initialising a periodic EvTimer, the after and repeat parameters should take the adjusted interval value from Timer. This takes into account any MIN_INTERVAL bounds are applied when initialising the Timer.

Fixes #236