### PR TITLE
Update supported PHP versions for loop extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
       - run: sudo apt-get update && sudo apt-get install libevent-dev
-      - name: Install ext-event between PHP 5.4 and PHP 7.x
+      - name: Install ext-event on PHP >= 5.4
         run: |
           echo "yes" | sudo pecl install event
           # explicitly enable extensions in php.ini on PHP 5.6+
           php -r 'exit((int)(PHP_VERSION_ID >= 50600));' || echo "extension=event.so" | sudo tee -a "$(php -r 'echo php_ini_loaded_file();')"
-        if: ${{ matrix.php >= 5.4 && matrix.php < 8.0 }}
+        if: ${{ matrix.php >= 5.4 }}
       - name: Install ext-ev on PHP >= 5.4
         run: |
           echo "yes" | sudo pecl install ev

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ A `stream_select()` based event loop.
 This uses the [`stream_select()`](https://www.php.net/manual/en/function.stream-select.php)
 function and is the only implementation that works out of the box with PHP.
 
-This event loop works out of the box on PHP 5.3 through PHP 7+ and HHVM.
+This event loop works out of the box on PHP 5.3 through PHP 8+ and HHVM.
 This means that no installation is required and this library works on all
 platforms and supported PHP versions.
 Accordingly, the [`Loop` class](#loop) and the deprecated [`Factory`](#factory)
@@ -397,7 +397,7 @@ This uses the [`event` PECL extension](https://pecl.php.net/package/event),
 that provides an interface to `libevent` library.
 `libevent` itself supports a number of system-specific backends (epoll, kqueue).
 
-This loop is known to work with PHP 5.4 through PHP 7+.
+This loop is known to work with PHP 5.4 through PHP 8+.
 
 #### ExtEvLoop
 
@@ -408,7 +408,7 @@ that provides an interface to `libev` library.
 `libev` itself supports a number of system-specific backends (epoll, kqueue).
 
 
-This loop is known to work with PHP 5.4 through PHP 7+.
+This loop is known to work with PHP 5.4 through PHP 8+.
 
 #### ExtUvLoop
 
@@ -418,7 +418,7 @@ This loop uses the [`uv` PECL extension](https://pecl.php.net/package/uv),
 that provides an interface to `libuv` library.
 `libuv` itself supports a number of system-specific backends (epoll, kqueue).
 
-This loop is known to work with PHP 7+.
+This loop is known to work with PHP 7.x.
 
 #### ~~ExtLibeventLoop~~
 

--- a/src/ExtEvLoop.php
+++ b/src/ExtEvLoop.php
@@ -16,7 +16,7 @@ use SplObjectStorage;
  * that provides an interface to `libev` library.
  * `libev` itself supports a number of system-specific backends (epoll, kqueue).
  *
- * This loop is known to work with PHP 5.4 through PHP 7+.
+ * This loop is known to work with PHP 5.4 through PHP 8+.
  *
  * @see http://php.net/manual/en/book.ev.php
  * @see https://bitbucket.org/osmanov/pecl-ev/overview

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -16,7 +16,7 @@ use SplObjectStorage;
  * that provides an interface to `libevent` library.
  * `libevent` itself supports a number of system-specific backends (epoll, kqueue).
  *
- * This loop is known to work with PHP 5.4 through PHP 7+.
+ * This loop is known to work with PHP 5.4 through PHP 8+.
  *
  * @link https://pecl.php.net/package/event
  */

--- a/src/ExtUvLoop.php
+++ b/src/ExtUvLoop.php
@@ -13,7 +13,7 @@ use SplObjectStorage;
  * that provides an interface to `libuv` library.
  * `libuv` itself supports a number of system-specific backends (epoll, kqueue).
  *
- * This loop is known to work with PHP 7+.
+ * This loop is known to work with PHP 7.x.
  *
  * @see https://github.com/bwoebi/php-uv
  */

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -12,7 +12,7 @@ use React\EventLoop\Timer\Timers;
  * This uses the [`stream_select()`](https://www.php.net/manual/en/function.stream-select.php)
  * function and is the only implementation that works out of the box with PHP.
  *
- * This event loop works out of the box on PHP 5.4 through PHP 7+ and HHVM.
+ * This event loop works out of the box on PHP 5.4 through PHP 8+ and HHVM.
  * This means that no installation is required and this library works on all
  * platforms and supported PHP versions.
  * Accordingly, the [`Loop` class](#loop) and the deprecated [`Factory`](#factory)


### PR DESCRIPTION
I checked and updated the supported PHP versions with the different loop extensions.

Builds on top of #238.