### PR TITLE
Add issue template for better orientation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,11 @@
+---
+name: Bug report
+about: Found a bug in our project? Create a report to help us improve.
+labels: bug
+---
+
+<!-- Add enough information so we can understand your problem -->
+
+```php
+// Please add code examples if possible, so we can reproduce your steps
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://reactphp.org/#support
+    about: 'If you discover a security vulnerability, please send us an email. Do not disclose security-related issues publicly.'
+  - name: Feature request
+    url: https://github.com/orgs/reactphp/discussions/categories/ideas
+    about: 'You have ideas to improve our project? Start a new discussion in our "Ideas" category.'
+  - name: Questions
+    url: https://github.com/orgs/reactphp/discussions/categories/q-a
+    about: 'We are happy to answer your questions! Start a new discussion in our "Q&A" category.'


### PR DESCRIPTION
This pull request adds issue templates to this project.

![grafik](https://user-images.githubusercontent.com/44357440/191731276-8e79faff-4087-4bc0-8156-2b793fe5f158.png)

With GitHub Discussions now activated on an organizational level (as discussed in https://github.com/reactphp/reactphp/issues/460), it makes sense to add issue templates to each ReactPHP repository to show users where they have to open up specific tickets. For more information look into https://github.com/reactphp/reactphp/pull/466.

Builds on top of https://github.com/reactphp/reactphp/pull/466