### PR TITLE
Update test suite and report failed assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-18.04 # legacy Ubuntu 18.04 for legacy libevent
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:
@@ -24,24 +24,46 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-      - run: sudo apt-get update && sudo apt-get install libevent-dev
-      - name: Install ext-event on PHP >= 5.4
-        run: |
-          echo "yes" | sudo pecl install event
-          # explicitly enable extensions in php.ini on PHP 5.6+
-          php -r 'exit((int)(PHP_VERSION_ID >= 50600));' || echo "extension=event.so" | sudo tee -a "$(php -r 'echo php_ini_loaded_file();')"
-        if: ${{ matrix.php >= 5.4 }}
-      - name: Install ext-ev on PHP >= 5.4
-        run: |
-          echo "yes" | sudo pecl install ev
-          # explicitly enable extensions in php.ini on PHP 5.6+
-          php -r 'exit((int)(PHP_VERSION_ID >= 50600));' || echo "extension=ev.so" | sudo tee -a "$(php -r 'echo php_ini_loaded_file();')"
-        if: ${{ matrix.php >= 5.4 }}
+          ini-file: development
+          ini-values: disable_functions='' # do not disable PCNTL functions on PHP < 8.1
+          extensions: sockets, pcntl ${{ matrix.php >= 5.6 && ', event' || '' }} ${{ matrix.php >= 5.4 && ', ev' || '' }}
+        env:
+          fail-fast: true # fail step if any extension can not be installed
+      - run: composer install
+      - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
+
+  PHPUnit-Unstable:
+    name: PHPUnit (Unstable PHP ${{ matrix.php }})
+    runs-on: ubuntu-20.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        php:
+          - 7.4
+          - 7.3
+          - 7.2
+          - 7.1
+          - 7.0
+          - 5.6
+          - 5.5
+          - 5.4
+          - 5.3
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+          ini-file: development
+          extensions: sockets, pcntl
       - name: Install ext-uv on PHP 7.x
         run: |
           sudo add-apt-repository ppa:ondrej/php -y && sudo apt-get update -q && sudo apt-get install libuv1-dev
@@ -50,6 +72,7 @@ jobs:
         if: ${{ matrix.php >= 7.0 && matrix.php < 8.0 }}
       - name: Install legacy ext-libevent on PHP < 7.0
         run: |
+          sudo apt-get update && sudo apt-get install libevent-dev
           curl http://pecl.php.net/get/libevent-0.1.0.tgz | tar -xz
           pushd libevent-0.1.0
           phpize
@@ -78,7 +101,7 @@ jobs:
 
   PHPUnit-Windows:
     name: PHPUnit (PHP ${{ matrix.php }} on Windows)
-    runs-on: windows-2019
+    runs-on: windows-2022
     continue-on-error: true
     strategy:
       matrix:
@@ -91,11 +114,12 @@ jobs:
           - 7.2
           - 7.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+          ini-file: development
           extensions: sockets,event # future: add uv-beta (installs, but can not load)
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
@@ -105,13 +129,16 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
+      - uses: actions/checkout@v3
+      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
+      - name: Run hhvm composer.phar install
+        uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
-          version: lts-3.30
-      - run: composer self-update --2.2 # downgrade Composer for HHVM
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit
+          args: hhvm composer.phar install
+      - name: Run hhvm vendor/bin/phpunit
+        uses: docker://hhvm/hhvm:3.30-lts-latest
+        with:
+          args: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EventLoop Component
+# EventLoop
 
 [![CI status](https://github.com/reactphp/event-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/reactphp/event-loop/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/react/event-loop?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/react/event-loop)
@@ -10,7 +10,7 @@ same event loop. This component provides a common `LoopInterface` that any
 library can target. This allows them to be used in the same loop, with one
 single [`run()`](#run) call that is controlled by the user.
 
-**Table of Contents**
+**Table of contents**
 
 * [Quickstart example](#quickstart-example)
 * [Usage](#usage)
@@ -897,7 +897,7 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 This project aims to run on any platform and thus does not require any PHP
 extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+It's *highly recommended to use the latest supported PHP version* for this project.
 
 Installing any of the event loop extensions is suggested, but entirely optional.
 See also [event loop implementations](#loop-implementations) for more details.

--- a/composer.json
+++ b/composer.json
@@ -29,21 +29,19 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     },
     "suggest": {
-        "ext-event": "~1.0 for ExtEventLoop",
-        "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
-        "ext-uv": "* for ExtUvLoop"
+        "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
     },
     "autoload": {
         "psr-4": {
-            "React\\EventLoop\\": "src"
+            "React\\EventLoop\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "React\\Tests\\EventLoop\\": "tests"
+            "React\\Tests\\EventLoop\\": "tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"
          convertDeprecationsToExceptions="true">
     <testsuites>
-        <testsuite name="React test suite">
+        <testsuite name="EventLoop Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
@@ -17,4 +17,12 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
+    </php>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>
-        <testsuite name="React test suite">
+        <testsuite name="EventLoop Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
@@ -15,4 +15,12 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
+    </php>
 </phpunit>

--- a/tests/AbstractLoopTest.php
+++ b/tests/AbstractLoopTest.php
@@ -657,11 +657,13 @@ abstract class AbstractLoopTest extends TestCase
 
     /**
      * @requires extension pcntl
+     * @requires function posix_kill()
+     * @requires function posix_getpid()
      */
     public function testSignal()
     {
-        if (!function_exists('posix_kill') || !function_exists('posix_getpid')) {
-            $this->markTestSkipped('Signal test skipped because functions "posix_kill" and "posix_getpid" are missing.');
+        if ($this->loop instanceof StreamSelectLoop && !(\function_exists('pcntl_signal') && \function_exists('pcntl_signal_dispatch'))) {
+            $this->markTestSkipped('Signal handling with StreamSelectLoop requires pcntl_signal() and pcntl_signal_dispatch(), see also disable_functions');
         }
 
         $called = false;
@@ -696,6 +698,10 @@ abstract class AbstractLoopTest extends TestCase
      */
     public function testSignalMultipleUsagesForTheSameListener()
     {
+        if ($this->loop instanceof StreamSelectLoop && !(\function_exists('pcntl_signal') && \function_exists('pcntl_signal_dispatch'))) {
+            $this->markTestSkipped('Signal handling with StreamSelectLoop requires pcntl_signal() and pcntl_signal_dispatch(), see also disable_functions');
+        }
+
         $funcCallCount = 0;
         $func = function () use (&$funcCallCount) {
             $funcCallCount++;
@@ -723,6 +729,10 @@ abstract class AbstractLoopTest extends TestCase
      */
     public function testSignalsKeepTheLoopRunning()
     {
+        if ($this->loop instanceof StreamSelectLoop && !(\function_exists('pcntl_signal') && \function_exists('pcntl_signal_dispatch'))) {
+            $this->markTestSkipped('Signal handling with StreamSelectLoop requires pcntl_signal() and pcntl_signal_dispatch(), see also disable_functions');
+        }
+
         $loop = $this->loop;
         $function = function () {};
         $this->loop->addSignal(SIGUSR1, $function);
@@ -739,6 +749,10 @@ abstract class AbstractLoopTest extends TestCase
      */
     public function testSignalsKeepTheLoopRunningAndRemovingItStopsTheLoop()
     {
+        if ($this->loop instanceof StreamSelectLoop && !(\function_exists('pcntl_signal') && \function_exists('pcntl_signal_dispatch'))) {
+            $this->markTestSkipped('Signal handling with StreamSelectLoop requires pcntl_signal() and pcntl_signal_dispatch(), see also disable_functions');
+        }
+
         $loop = $this->loop;
         $function = function () {};
         $this->loop->addSignal(SIGUSR1, $function);

--- a/tests/StreamSelectLoopTest.php
+++ b/tests/StreamSelectLoopTest.php
@@ -132,6 +132,8 @@ class StreamSelectLoopTest extends AbstractLoopTest
      * Test signal interrupt when no stream is attached to the loop
      * @dataProvider signalProvider
      * @requires extension pcntl
+     * @requires function pcntl_signal()
+     * @requires function pcntl_signal_dispatch()
      */
     public function testSignalInterruptNoStream($signal)
     {
@@ -160,6 +162,8 @@ class StreamSelectLoopTest extends AbstractLoopTest
      * Test signal interrupt when a stream is attached to the loop
      * @dataProvider signalProvider
      * @requires extension pcntl
+     * @requires function pcntl_signal()
+     * @requires function pcntl_signal_dispatch()
      */
     public function testSignalInterruptWithStream($signal)
     {


### PR DESCRIPTION
This changeset updates the test suite and makes sure we report any failed assertions as already discussed in https://github.com/reactphp/socket/pull/299 and https://github.com/reactphp/socket/pull/300.

In particular, we now test stable and "unstable" (or legacy) extensions separately (see also #250). Porting the test suite to latest versions was relatively straight forward, but you're also looking at several hours of work to make sure any legacy versions continue to work as is, yey! As discussed in #230, we may get rid of these legacy installations in the future and there's potential to significantly simplify this setup by installing extensions using the respective GitHub action instead (see also future plans for ReactPHP v3 as discussed in https://github.com/orgs/reactphp/discussions/481).

Builds on top of #258, #251, #250, #230, https://github.com/reactphp/socket/pull/299 and https://github.com/reactphp/socket/pull/300