### PR TITLE
Support checking `EINTR` constant from `ext-pcntl` without `ext-sockets`

### DIFF
--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -290,7 +290,8 @@ final class StreamSelectLoop implements LoopInterface
             /** @var ?callable $previous */
             $previous = \set_error_handler(function ($errno, $errstr) use (&$previous) {
                 // suppress warnings that occur when `stream_select()` is interrupted by a signal
-                $eintr = \defined('SOCKET_EINTR') ? \SOCKET_EINTR : 4;
+                // PHP defines `EINTR` through `ext-sockets` or `ext-pcntl`, otherwise use common default (Linux & Mac)
+                $eintr = \defined('SOCKET_EINTR') ? \SOCKET_EINTR : (\defined('PCNTL_EINTR') ? \PCNTL_EINTR : 4);
                 if ($errno === \E_WARNING && \strpos($errstr, '[' . $eintr .']: ') !== false) {
                     return;
                 }


### PR DESCRIPTION
This changeset adds support for checking the `EINTR` constant from `ext-pcntl` when `ext-sockets` is not available. This is useful in minimal container images (Docker) that do not ship `ext-sockets` by default and also because signal handling support using the default `StreamSelectLoop` requires `ext-pcntl` anyway. This should not affect most platforms as the hard-coded fallback value when neither extension is available is known to work on Linux and Mac in either case.

Builds on top of https://github.com/reactphp/socket/pull/304, #245 and #264