### PR TITLE
Improve performance of `Loop` by avoiding unneeded method calls

### DIFF
--- a/src/Loop.php
+++ b/src/Loop.php
@@ -8,7 +8,7 @@ namespace React\EventLoop;
 final class Loop
 {
     /**
-     * @var LoopInterface
+     * @var ?LoopInterface
      */
     private static $instance;
 
@@ -83,7 +83,11 @@ final class Loop
      */
     public static function addReadStream($stream, $listener)
     {
-        self::get()->addReadStream($stream, $listener);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+        self::$instance->addReadStream($stream, $listener);
     }
 
     /**
@@ -97,7 +101,11 @@ final class Loop
      */
     public static function addWriteStream($stream, $listener)
     {
-        self::get()->addWriteStream($stream, $listener);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+        self::$instance->addWriteStream($stream, $listener);
     }
 
     /**
@@ -109,7 +117,9 @@ final class Loop
      */
     public static function removeReadStream($stream)
     {
-        self::get()->removeReadStream($stream);
+        if (self::$instance !== null) {
+            self::$instance->removeReadStream($stream);
+        }
     }
 
     /**
@@ -121,7 +131,9 @@ final class Loop
      */
     public static function removeWriteStream($stream)
     {
-        self::get()->removeWriteStream($stream);
+        if (self::$instance !== null) {
+            self::$instance->removeWriteStream($stream);
+        }
     }
 
     /**
@@ -134,7 +146,11 @@ final class Loop
      */
     public static function addTimer($interval, $callback)
     {
-        return self::get()->addTimer($interval, $callback);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+        return self::$instance->addTimer($interval, $callback);
     }
 
     /**
@@ -147,7 +163,11 @@ final class Loop
      */
     public static function addPeriodicTimer($interval, $callback)
     {
-        return self::get()->addPeriodicTimer($interval, $callback);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+        return self::$instance->addPeriodicTimer($interval, $callback);
     }
 
     /**
@@ -159,7 +179,9 @@ final class Loop
      */
     public static function cancelTimer(TimerInterface $timer)
     {
-        return self::get()->cancelTimer($timer);
+        if (self::$instance !== null) {
+            self::$instance->cancelTimer($timer);
+        }
     }
 
     /**
@@ -171,7 +193,12 @@ final class Loop
      */
     public static function futureTick($listener)
     {
-        self::get()->futureTick($listener);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+
+        self::$instance->futureTick($listener);
     }
 
     /**
@@ -184,7 +211,12 @@ final class Loop
      */
     public static function addSignal($signal, $listener)
     {
-        self::get()->addSignal($signal, $listener);
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+
+        self::$instance->addSignal($signal, $listener);
     }
 
     /**
@@ -197,7 +229,9 @@ final class Loop
      */
     public static function removeSignal($signal, $listener)
     {
-        self::get()->removeSignal($signal, $listener);
+        if (self::$instance !== null) {
+            self::$instance->removeSignal($signal, $listener);
+        }
     }
 
     /**
@@ -208,7 +242,12 @@ final class Loop
      */
     public static function run()
     {
-        self::get()->run();
+        // create loop instance on demand (legacy PHP < 7 doesn't like ternaries in method calls)
+        if (self::$instance === null) {
+            self::get();
+        }
+
+        self::$instance->run();
     }
 
     /**
@@ -220,6 +259,8 @@ final class Loop
     public static function stop()
     {
         self::$stopped = true;
-        self::get()->stop();
+        if (self::$instance !== null) {
+            self::$instance->stop();
+        }
     }
 }

--- a/tests/LoopTest.php
+++ b/tests/LoopTest.php
@@ -62,6 +62,19 @@ final class LoopTest extends TestCase
         Loop::addReadStream($stream, $listener);
     }
 
+    public function testStaticAddReadStreamWithNoDefaultLoopCallsAddReadStreamOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $stream = stream_socket_server('127.0.0.1:0');
+        $listener = function () { };
+        Loop::addReadStream($stream, $listener);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
+    }
+
     public function testStaticAddWriteStreamCallsAddWriteStreamOnLoopInstance()
     {
         $stream = tmpfile();
@@ -73,6 +86,19 @@ final class LoopTest extends TestCase
         Loop::set($loop);
 
         Loop::addWriteStream($stream, $listener);
+    }
+
+    public function testStaticAddWriteStreamWithNoDefaultLoopCallsAddWriteStreamOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $stream = stream_socket_server('127.0.0.1:0');
+        $listener = function () { };
+        Loop::addWriteStream($stream, $listener);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
     }
 
     public function testStaticRemoveReadStreamCallsRemoveReadStreamOnLoopInstance()
@@ -87,6 +113,18 @@ final class LoopTest extends TestCase
         Loop::removeReadStream($stream);
     }
 
+    public function testStaticRemoveReadStreamWithNoDefaultLoopIsNoOp()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $stream = tmpfile();
+        Loop::removeReadStream($stream);
+
+        $this->assertNull($ref->getValue());
+    }
+
     public function testStaticRemoveWriteStreamCallsRemoveWriteStreamOnLoopInstance()
     {
         $stream = tmpfile();
@@ -97,6 +135,18 @@ final class LoopTest extends TestCase
         Loop::set($loop);
 
         Loop::removeWriteStream($stream);
+    }
+
+    public function testStaticRemoveWriteStreamWithNoDefaultLoopIsNoOp()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $stream = tmpfile();
+        Loop::removeWriteStream($stream);
+
+        $this->assertNull($ref->getValue());
     }
 
     public function testStaticAddTimerCallsAddTimerOnLoopInstanceAndReturnsTimerInstance()
@@ -115,6 +165,20 @@ final class LoopTest extends TestCase
         $this->assertSame($timer, $ret);
     }
 
+    public function testStaticAddTimerWithNoDefaultLoopCallsAddTimerOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $interval = 1.0;
+        $callback = function () { };
+        $ret = Loop::addTimer($interval, $callback);
+
+        $this->assertInstanceOf('React\EventLoop\TimerInterface', $ret);
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
+    }
+
     public function testStaticAddPeriodicTimerCallsAddPeriodicTimerOnLoopInstanceAndReturnsTimerInstance()
     {
         $interval = 1.0;
@@ -131,6 +195,21 @@ final class LoopTest extends TestCase
         $this->assertSame($timer, $ret);
     }
 
+    public function testStaticAddPeriodicTimerWithNoDefaultLoopCallsAddPeriodicTimerOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $interval = 1.0;
+        $callback = function () { };
+        $ret = Loop::addPeriodicTimer($interval, $callback);
+
+        $this->assertInstanceOf('React\EventLoop\TimerInterface', $ret);
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
+    }
+
+
     public function testStaticCancelTimerCallsCancelTimerOnLoopInstance()
     {
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
@@ -143,6 +222,18 @@ final class LoopTest extends TestCase
         Loop::cancelTimer($timer);
     }
 
+    public function testStaticCancelTimerWithNoDefaultLoopIsNoOp()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        Loop::cancelTimer($timer);
+
+        $this->assertNull($ref->getValue());
+    }
+
     public function testStaticFutureTickCallsFutureTickOnLoopInstance()
     {
         $listener = function () { };
@@ -153,6 +244,18 @@ final class LoopTest extends TestCase
         Loop::set($loop);
 
         Loop::futureTick($listener);
+    }
+
+    public function testStaticFutureTickWithNoDefaultLoopCallsFutureTickOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $listener = function () { };
+        Loop::futureTick($listener);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
     }
 
     public function testStaticAddSignalCallsAddSignalOnLoopInstance()
@@ -168,6 +271,27 @@ final class LoopTest extends TestCase
         Loop::addSignal($signal, $listener);
     }
 
+    public function testStaticAddSignalWithNoDefaultLoopCallsAddSignalOnNewLoopInstance()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Not supported on Windows');
+        }
+
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $signal = 1;
+        $listener = function () { };
+        try {
+            Loop::addSignal($signal, $listener);
+        } catch (\BadMethodCallException $e) {
+            $this->markTestSkipped('Skipped: ' . $e->getMessage());
+        }
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
+    }
+
     public function testStaticRemoveSignalCallsRemoveSignalOnLoopInstance()
     {
         $signal = 1;
@@ -181,6 +305,19 @@ final class LoopTest extends TestCase
         Loop::removeSignal($signal, $listener);
     }
 
+    public function testStaticRemoveSignalWithNoDefaultLoopIsNoOp()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        $signal = 1;
+        $listener = function () { };
+        Loop::removeSignal($signal, $listener);
+
+        $this->assertNull($ref->getValue());
+    }
+
     public function testStaticRunCallsRunOnLoopInstance()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -191,6 +328,17 @@ final class LoopTest extends TestCase
         Loop::run();
     }
 
+    public function testStaticRunWithNoDefaultLoopCallsRunsOnNewLoopInstance()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        Loop::run();
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $ref->getValue());
+    }
+
     public function testStaticStopCallsStopOnLoopInstance()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -199,6 +347,17 @@ final class LoopTest extends TestCase
         Loop::set($loop);
 
         Loop::stop();
+    }
+
+    public function testStaticStopCallWithNoDefaultLoopIsNoOp()
+    {
+        $ref = new \ReflectionProperty('React\EventLoop\Loop', 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null);
+
+        Loop::stop();
+
+        $this->assertNull($ref->getValue());
     }
 
     /**


### PR DESCRIPTION
This changeset improves performance of `Loop` slightly by avoiding unneeded method calls. Not the most significant improvement, but given the small changeset and how we plan to make the default `Loop` more prominent in ReactPHP v3, I figured this change makes sense in either case:

```bash
$ time php examples/91-benchmark-ticks.php 1000000
// old 0.83
// new 0.76
```

Builds on top of #245 and #229
See also https://github.com/orgs/reactphp/discussions/481