### PR TITLE
Improve performance by using `spl_object_id()` on PHP 7.2+

### DIFF
--- a/src/Timer/Timers.php
+++ b/src/Timer/Timers.php
@@ -38,7 +38,7 @@ final class Timers
 
     public function add(TimerInterface $timer)
     {
-        $id = \spl_object_hash($timer);
+        $id = \PHP_VERSION_ID < 70200 ? \spl_object_hash($timer) : \spl_object_id($timer);
         $this->timers[$id] = $timer;
         $this->schedule[$id] = $timer->getInterval() + $this->updateTime();
         $this->sorted = false;
@@ -46,12 +46,13 @@ final class Timers
 
     public function contains(TimerInterface $timer)
     {
-        return isset($this->timers[\spl_object_hash($timer)]);
+        $id = \PHP_VERSION_ID < 70200 ? \spl_object_hash($timer) : \spl_object_id($timer);
+        return isset($this->timers[$id]);
     }
 
     public function cancel(TimerInterface $timer)
     {
-        $id = \spl_object_hash($timer);
+        $id = \PHP_VERSION_ID < 70200 ? \spl_object_hash($timer) : \spl_object_id($timer);
         unset($this->timers[$id], $this->schedule[$id]);
     }
 


### PR DESCRIPTION
`spl_object_id()` is exists since php 7.2, I think `spl_object_id()` can be used when php version >= 7.2

Refs:

- https://github.com/php/php-src/pull/2611
- https://developer.wordpress.com/2023/08/24/speedier-php-execution-in-wordpress-6-3/

Same implementation in reactphp/http:

https://github.com/reactphp/http/blob/c6321978bfb82de979fe4dc28eb0c08bc34937ad/src/Io/RequestHeaderParser.php#L165

**Benchmark**

**Before** **_call in loop took: 13.639ms_**

https://3v4l.org/4rUL4

**After**  **_call in loop took: 4.835ms_**

https://3v4l.org/jKtO6
