### PR TITLE
Install uv-extension in v0.2.4 for PHP 7.x in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install ext-uv on PHP 7.x
         run: |
           sudo add-apt-repository ppa:ondrej/php -y && sudo apt-get update -q && sudo apt-get install libuv1-dev
-          echo "yes" | sudo pecl install uv-beta
+          echo "yes" | sudo pecl install uv-0.2.4
           echo "extension=uv.so" >> "$(php -r 'echo php_ini_loaded_file();')"
         if: ${{ matrix.php >= 7.0 && matrix.php < 8.0 }}
       - name: Install legacy ext-libevent on PHP < 7.0


### PR DESCRIPTION
This pull request updates the test matrix to install the pecl/uv extension in v0.2.4. Previously, we were always installing the latest version of this extension, which caused installation failures for pecl/uv on PHP 7 after the latest release of v0.3.0. This new version is only compatible with PHP 8 and above, I went back to the latest known version that works for PHP 7.

We became aware of this issue after @samsonasik test suite execution failed in #267.

For more reference about pecl/uv versions see: https://pecl.php.net/package/uv 
Builds on top of #264.