### PR TITLE
Hello `3.x` development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 [ReactPHP](https://reactphp.org/)'s core reactor event loop that libraries can use for evented I/O.
 
+> **Development version:** This branch contains the code for the upcoming v3 
+> release. For the code of the current stable v1 release, check out the 
+> [`1.x` branch](https://github.com/reactphp/event-loop/tree/1.x).
+>
+> The upcoming v3 release will be the way forward for this package. However,
+> we will still actively support v1 for those not yet on the latest version. 
+> See also [installation instructions](#install) for more details.
+
 In order for async based libraries to be interoperable, they need to use the
 same event loop. This component provides a common `LoopInterface` that any
 library can target. This allows them to be used in the same loop, with one
@@ -885,11 +893,11 @@ to remove a stream that was never added or is invalid has no effect.
 The recommended way to install this library is [through Composer](https://getcomposer.org/).
 [New to Composer?](https://getcomposer.org/doc/00-intro.md)
 
-This project follows [SemVer](https://semver.org/).
-This will install the latest supported version:
+Once released, this project will follow [SemVer](https://semver.org/).
+At the moment, this will install the latest development version:
 
 ```bash
-composer require react/event-loop:^1.5
+composer require react/event-loop:^3@dev
 ```
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.


### PR DESCRIPTION
Once this PR is merged, we can start working on the new [v3.0.0 milestone](https://github.com/reactphp/event-loop/milestone/15). The default branch will be `3.x` and the old `1.x` branch still stay in place at least until `3.0.0` is released.

Refs:
Road map ticket for event-loop: #271
Plans for ReactPHP v3: https://github.com/orgs/reactphp/discussions/481
PR templated from: https://github.com/friends-of-reactphp/mysql/pull/185