### PR TITLE
Add native types to public API

### DIFF
--- a/src/ExtEvLoop.php
+++ b/src/ExtEvLoop.php
@@ -71,7 +71,7 @@ class ExtEvLoop implements LoopInterface
         $this->signals = new SignalsHandler();
     }
 
-    public function addReadStream($stream, $listener)
+    public function addReadStream($stream, callable $listener): void
     {
         $key = (int)$stream;
 
@@ -97,7 +97,7 @@ class ExtEvLoop implements LoopInterface
         };
     }
 
-    public function addWriteStream($stream, $listener)
+    public function addWriteStream($stream, callable $listener): void
     {
         $key = (int)$stream;
 
@@ -110,7 +110,7 @@ class ExtEvLoop implements LoopInterface
         $this->writeStreams[$key] = $event;
     }
 
-    public function removeReadStream($stream)
+    public function removeReadStream($stream): void
     {
         $key = (int)$stream;
 
@@ -122,7 +122,7 @@ class ExtEvLoop implements LoopInterface
         unset($this->readStreams[$key]);
     }
 
-    public function removeWriteStream($stream)
+    public function removeWriteStream($stream): void
     {
         $key = (int)$stream;
 
@@ -134,7 +134,7 @@ class ExtEvLoop implements LoopInterface
         unset($this->writeStreams[$key]);
     }
 
-    public function addTimer($interval, $callback)
+    public function addTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -152,7 +152,7 @@ class ExtEvLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, $callback)
+    public function addPeriodicTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -166,7 +166,7 @@ class ExtEvLoop implements LoopInterface
         return $timer;
     }
 
-    public function cancelTimer(TimerInterface $timer)
+    public function cancelTimer(TimerInterface $timer): void
     {
         if (!isset($this->timers[$timer])) {
             return;
@@ -177,12 +177,12 @@ class ExtEvLoop implements LoopInterface
         $this->timers->detach($timer);
     }
 
-    public function futureTick($listener)
+    public function futureTick(callable $listener): void
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function run()
+    public function run(): void
     {
         $this->running = true;
 
@@ -207,7 +207,7 @@ class ExtEvLoop implements LoopInterface
         }
     }
 
-    public function stop()
+    public function stop(): void
     {
         $this->running = false;
     }
@@ -228,7 +228,7 @@ class ExtEvLoop implements LoopInterface
         }
     }
 
-    public function addSignal($signal, $listener)
+    public function addSignal(int $signal, callable $listener): void
     {
         $this->signals->add($signal, $listener);
 
@@ -239,7 +239,7 @@ class ExtEvLoop implements LoopInterface
         }
     }
 
-    public function removeSignal($signal, $listener)
+    public function removeSignal(int $signal, callable $listener): void
     {
         $this->signals->remove($signal, $listener);
 

--- a/src/ExtEventLoop.php
+++ b/src/ExtEventLoop.php
@@ -71,7 +71,7 @@ final class ExtEventLoop implements LoopInterface
         $this->writeEvents = [];
     }
 
-    public function addReadStream($stream, $listener)
+    public function addReadStream($stream, callable $listener): void
     {
         $key = (int) $stream;
         if (isset($this->readListeners[$key])) {
@@ -88,7 +88,7 @@ final class ExtEventLoop implements LoopInterface
         $this->readRefs[$key] = $stream;
     }
 
-    public function addWriteStream($stream, $listener)
+    public function addWriteStream($stream, callable $listener): void
     {
         $key = (int) $stream;
         if (isset($this->writeListeners[$key])) {
@@ -105,7 +105,7 @@ final class ExtEventLoop implements LoopInterface
         $this->writeRefs[$key] = $stream;
     }
 
-    public function removeReadStream($stream)
+    public function removeReadStream($stream): void
     {
         $key = (int) $stream;
 
@@ -119,7 +119,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function removeWriteStream($stream)
+    public function removeWriteStream($stream): void
     {
         $key = (int) $stream;
 
@@ -133,7 +133,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function addTimer($interval, $callback)
+    public function addTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -142,7 +142,7 @@ final class ExtEventLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, $callback)
+    public function addPeriodicTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -151,7 +151,7 @@ final class ExtEventLoop implements LoopInterface
         return $timer;
     }
 
-    public function cancelTimer(TimerInterface $timer)
+    public function cancelTimer(TimerInterface $timer): void
     {
         if ($this->timerEvents->contains($timer)) {
             $this->timerEvents[$timer]->free();
@@ -159,12 +159,12 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function futureTick($listener)
+    public function futureTick(callable $listener): void
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, $listener)
+    public function addSignal(int $signal, callable $listener): void
     {
         $this->signals->add($signal, $listener);
 
@@ -174,7 +174,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function removeSignal($signal, $listener)
+    public function removeSignal(int $signal, callable $listener): void
     {
         $this->signals->remove($signal, $listener);
 
@@ -184,7 +184,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function run()
+    public function run(): void
     {
         $this->running = true;
 
@@ -202,7 +202,7 @@ final class ExtEventLoop implements LoopInterface
         }
     }
 
-    public function stop()
+    public function stop(): void
     {
         $this->running = false;
     }

--- a/src/ExtUvLoop.php
+++ b/src/ExtUvLoop.php
@@ -58,7 +58,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addReadStream($stream, $listener)
+    public function addReadStream($stream, callable $listener): void
     {
         if (isset($this->readStreams[(int) $stream])) {
             return;
@@ -71,7 +71,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addWriteStream($stream, $listener)
+    public function addWriteStream($stream, callable $listener): void
     {
         if (isset($this->writeStreams[(int) $stream])) {
             return;
@@ -84,7 +84,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeReadStream($stream)
+    public function removeReadStream($stream): void
     {
         if (!isset($this->streamEvents[(int) $stream])) {
             return;
@@ -97,7 +97,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function removeWriteStream($stream)
+    public function removeWriteStream($stream): void
     {
         if (!isset($this->streamEvents[(int) $stream])) {
             return;
@@ -110,7 +110,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addTimer($interval, $callback)
+    public function addTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -137,7 +137,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function addPeriodicTimer($interval, $callback)
+    public function addPeriodicTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -161,7 +161,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function cancelTimer(TimerInterface $timer)
+    public function cancelTimer(TimerInterface $timer): void
     {
         if (isset($this->timers[$timer])) {
             @\uv_timer_stop($this->timers[$timer]);
@@ -172,12 +172,12 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function futureTick($listener)
+    public function futureTick(callable $listener): void
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, $listener)
+    public function addSignal(int $signal, callable $listener): void
     {
         $this->signals->add($signal, $listener);
 
@@ -189,7 +189,7 @@ final class ExtUvLoop implements LoopInterface
         }
     }
 
-    public function removeSignal($signal, $listener)
+    public function removeSignal(int $signal, callable $listener): void
     {
         $this->signals->remove($signal, $listener);
 
@@ -202,7 +202,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function run()
+    public function run(): void
     {
         $this->running = true;
 
@@ -233,7 +233,7 @@ final class ExtUvLoop implements LoopInterface
     /**
      * {@inheritdoc}
      */
-    public function stop()
+    public function stop(): void
     {
         $this->running = false;
     }

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -27,7 +27,7 @@ final class Loop
      *
      * @return LoopInterface
      */
-    public static function get()
+    public static function get(): LoopInterface
     {
         if (self::$instance instanceof LoopInterface) {
             return self::$instance;
@@ -80,7 +80,7 @@ final class Loop
      * @throws \Exception
      * @see LoopInterface::addReadStream()
      */
-    public static function addReadStream($stream, $listener)
+    public static function addReadStream($stream, callable $listener): void
     {
         (self::$instance ?? self::get())->addReadStream($stream, $listener);
     }
@@ -94,7 +94,7 @@ final class Loop
      * @throws \Exception
      * @see LoopInterface::addWriteStream()
      */
-    public static function addWriteStream($stream, $listener)
+    public static function addWriteStream($stream, callable $listener): void
     {
         (self::$instance ?? self::get())->addWriteStream($stream, $listener);
     }
@@ -106,7 +106,7 @@ final class Loop
      * @return void
      * @see LoopInterface::removeReadStream()
      */
-    public static function removeReadStream($stream)
+    public static function removeReadStream($stream): void
     {
         if (self::$instance !== null) {
             self::$instance->removeReadStream($stream);
@@ -120,7 +120,7 @@ final class Loop
      * @return void
      * @see LoopInterface::removeWriteStream()
      */
-    public static function removeWriteStream($stream)
+    public static function removeWriteStream($stream): void
     {
         if (self::$instance !== null) {
             self::$instance->removeWriteStream($stream);
@@ -135,7 +135,7 @@ final class Loop
      * @return TimerInterface
      * @see LoopInterface::addTimer()
      */
-    public static function addTimer($interval, $callback)
+    public static function addTimer(float $interval, callable $callback): TimerInterface
     {
         return (self::$instance ?? self::get())->addTimer($interval, $callback);
     }
@@ -148,7 +148,7 @@ final class Loop
      * @return TimerInterface
      * @see LoopInterface::addPeriodicTimer()
      */
-    public static function addPeriodicTimer($interval, $callback)
+    public static function addPeriodicTimer(float $interval, callable $callback): TimerInterface
     {
         return (self::$instance ?? self::get())->addPeriodicTimer($interval, $callback);
     }
@@ -160,7 +160,7 @@ final class Loop
      * @return void
      * @see LoopInterface::cancelTimer()
      */
-    public static function cancelTimer(TimerInterface $timer)
+    public static function cancelTimer(TimerInterface $timer): void
     {
         if (self::$instance !== null) {
             self::$instance->cancelTimer($timer);
@@ -174,7 +174,7 @@ final class Loop
      * @return void
      * @see LoopInterface::futureTick()
      */
-    public static function futureTick($listener)
+    public static function futureTick(callable $listener): void
     {
         (self::$instance ?? self::get())->futureTick($listener);
     }
@@ -187,7 +187,7 @@ final class Loop
      * @return void
      * @see LoopInterface::addSignal()
      */
-    public static function addSignal($signal, $listener)
+    public static function addSignal(int $signal, callable $listener): void
     {
         (self::$instance ?? self::get())->addSignal($signal, $listener);
     }
@@ -200,7 +200,7 @@ final class Loop
      * @return void
      * @see LoopInterface::removeSignal()
      */
-    public static function removeSignal($signal, $listener)
+    public static function removeSignal(int $signal, callable $listener): void
     {
         if (self::$instance !== null) {
             self::$instance->removeSignal($signal, $listener);
@@ -213,7 +213,7 @@ final class Loop
      * @return void
      * @see LoopInterface::run()
      */
-    public static function run()
+    public static function run(): void
     {
         (self::$instance ?? self::get())->run();
     }
@@ -224,7 +224,7 @@ final class Loop
      * @return void
      * @see LoopInterface::stop()
      */
-    public static function stop()
+    public static function stop(): void
     {
         self::$stopped = true;
         if (self::$instance !== null) {

--- a/src/LoopInterface.php
+++ b/src/LoopInterface.php
@@ -52,7 +52,7 @@ interface LoopInterface
      * @throws \Exception if the given resource type is not supported by this loop implementation
      * @see self::removeReadStream()
      */
-    public function addReadStream($stream, $listener);
+    public function addReadStream($stream, callable $listener): void;
 
     /**
      * [Advanced] Register a listener to be notified when a stream is ready to write.
@@ -110,7 +110,7 @@ interface LoopInterface
      * @throws \Exception if the given resource type is not supported by this loop implementation
      * @see self::removeWriteStream()
      */
-    public function addWriteStream($stream, $listener);
+    public function addWriteStream($stream, callable $listener): void;
 
     /**
      * Remove the read event listener for the given stream.
@@ -120,7 +120,7 @@ interface LoopInterface
      *
      * @param resource $stream The PHP stream resource.
      */
-    public function removeReadStream($stream);
+    public function removeReadStream($stream): void;
 
     /**
      * Remove the write event listener for the given stream.
@@ -130,7 +130,7 @@ interface LoopInterface
      *
      * @param resource $stream The PHP stream resource.
      */
-    public function removeWriteStream($stream);
+    public function removeWriteStream($stream): void;
 
     /**
      * Enqueue a callback to be invoked once after the given interval.
@@ -204,7 +204,7 @@ interface LoopInterface
      *
      * @return TimerInterface
      */
-    public function addTimer($interval, $callback);
+    public function addTimer(float $interval, callable $callback): TimerInterface;
 
     /**
      * Enqueue a callback to be invoked repeatedly after the given interval.
@@ -290,7 +290,7 @@ interface LoopInterface
      *
      * @return TimerInterface
      */
-    public function addPeriodicTimer($interval, $callback);
+    public function addPeriodicTimer(float $interval, callable $callback): TimerInterface;
 
     /**
      * Cancel a pending timer.
@@ -304,7 +304,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function cancelTimer(TimerInterface $timer);
+    public function cancelTimer(TimerInterface $timer): void;
 
     /**
      * Schedule a callback to be invoked on a future tick of the event loop.
@@ -356,7 +356,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function futureTick($listener);
+    public function futureTick(callable $listener): void;
 
     /**
      * Register a listener to be notified when a signal has been caught by this process.
@@ -399,7 +399,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function addSignal($signal, $listener);
+    public function addSignal(int $signal, callable $listener): void;
 
     /**
      * Removes a previously added signal listener.
@@ -415,7 +415,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function removeSignal($signal, $listener);
+    public function removeSignal(int $signal, callable $listener): void;
 
     /**
      * Run the event loop until there are no more tasks to perform.
@@ -446,7 +446,7 @@ interface LoopInterface
      *
      * @return void
      */
-    public function run();
+    public function run(): void;
 
     /**
      * Instruct a running event loop to stop.
@@ -468,5 +468,5 @@ interface LoopInterface
      *
      * @return void
      */
-    public function stop();
+    public function stop(): void;
 }

--- a/src/StreamSelectLoop.php
+++ b/src/StreamSelectLoop.php
@@ -79,7 +79,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function addReadStream($stream, $listener)
+    public function addReadStream($stream, callable $listener): void
     {
         $key = (int) $stream;
 
@@ -89,7 +89,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function addWriteStream($stream, $listener)
+    public function addWriteStream($stream, callable $listener): void
     {
         $key = (int) $stream;
 
@@ -99,7 +99,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function removeReadStream($stream)
+    public function removeReadStream($stream): void
     {
         $key = (int) $stream;
 
@@ -109,7 +109,7 @@ final class StreamSelectLoop implements LoopInterface
         );
     }
 
-    public function removeWriteStream($stream)
+    public function removeWriteStream($stream): void
     {
         $key = (int) $stream;
 
@@ -119,7 +119,7 @@ final class StreamSelectLoop implements LoopInterface
         );
     }
 
-    public function addTimer($interval, $callback)
+    public function addTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, false);
 
@@ -128,7 +128,7 @@ final class StreamSelectLoop implements LoopInterface
         return $timer;
     }
 
-    public function addPeriodicTimer($interval, $callback)
+    public function addPeriodicTimer(float $interval, callable $callback): TimerInterface
     {
         $timer = new Timer($interval, $callback, true);
 
@@ -137,17 +137,17 @@ final class StreamSelectLoop implements LoopInterface
         return $timer;
     }
 
-    public function cancelTimer(TimerInterface $timer)
+    public function cancelTimer(TimerInterface $timer): void
     {
         $this->timers->cancel($timer);
     }
 
-    public function futureTick($listener)
+    public function futureTick(callable $listener): void
     {
         $this->futureTickQueue->add($listener);
     }
 
-    public function addSignal($signal, $listener)
+    public function addSignal(int $signal, callable $listener): void
     {
         if ($this->pcntl === false) {
             throw new \BadMethodCallException('Event loop feature "signals" isn\'t supported by the "StreamSelectLoop"');
@@ -161,7 +161,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function removeSignal($signal, $listener)
+    public function removeSignal(int $signal, callable $listener): void
     {
         if (!$this->signals->count($signal)) {
             return;
@@ -174,7 +174,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function run()
+    public function run(): void
     {
         $this->running = true;
 
@@ -213,7 +213,7 @@ final class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function stop()
+    public function stop(): void
     {
         $this->running = false;
     }

--- a/src/Timer/Timer.php
+++ b/src/Timer/Timer.php
@@ -38,17 +38,17 @@ final class Timer implements TimerInterface
         $this->periodic = (bool) $periodic;
     }
 
-    public function getInterval()
+    public function getInterval(): float
     {
         return $this->interval;
     }
 
-    public function getCallback()
+    public function getCallback(): callable
     {
         return $this->callback;
     }
 
-    public function isPeriodic()
+    public function isPeriodic(): bool
     {
         return $this->periodic;
     }

--- a/src/TimerInterface.php
+++ b/src/TimerInterface.php
@@ -9,19 +9,19 @@ interface TimerInterface
      *
      * @return float
      */
-    public function getInterval();
+    public function getInterval(): float;
 
     /**
      * Get the callback that will be executed when this timer elapses
      *
      * @return callable
      */
-    public function getCallback();
+    public function getCallback(): callable;
 
     /**
      * Determine whether the time is periodic
      *
      * @return bool
      */
-    public function isPeriodic();
+    public function isPeriodic(): bool;
 }


### PR DESCRIPTION
This changeset adds native types to the public API as discussed in #271.

Once merged, I'm planning to add PHPStan in a follow-up PR which would take advantage of these types.

Builds on top of #276 and https://github.com/reactphp/cache/pull/60