### PR TITLE
[3.x] Update test environment for PHP 7.2 to compatible PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^7.5"
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^7.5"
     },
     "suggest": {
         "ext-pcntl": "For signal handling support when using the StreamSelectLoop"


### PR DESCRIPTION
Since [composer `2.9`](https://github.com/composer/composer/releases/tag/2.9.0) it blocks installing package versions with [known CVE's](https://github.com/composer/composer/pull/11956). This only affects PHP version 7.2 and up, 7.1 and lower use composer `2.2.27` (at the time of writing). So any open CVE's aren't an issue when running composer install. The reason this became an issue now is that with [`CVE-2026-24765`](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) affecting all PHPUnit versions before versions `8.5.52`, `9.6.33`, `10.5.62`, `11.5.50`, and `12.5.8`. There is no PHPUnit version in the `^7.5` range that isn't effected, this we're adding `^8.5` to the version range and thus we get the only not impacted version in te `^8.5` range `8.5.52`.